### PR TITLE
Corrected the BaseSetupImpl on Line 21 of end_to_end_test.go

### DIFF
--- a/test/integration/end_to_end_test.go
+++ b/test/integration/end_to_end_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestChainCodeInvoke(t *testing.T) {
 
-	testSetup := BaseSetupImpl{
+	testSetup := &BaseSetupImpl{
 		ConfigFile:      "../fixtures/config/config_test.yaml",
 		ChannelID:       "mychannel",
 		OrgID:           "peerorg1",
@@ -46,7 +46,7 @@ func TestChainCodeInvoke(t *testing.T) {
 	// Register callback for chaincode event
 	done, rce := fabricTxn.RegisterCCEvent(testSetup.ChainCodeID, eventID, testSetup.EventHub)
 
-	err = moveFunds(&testSetup)
+	err = moveFunds(testSetup)
 	if err != nil {
 		t.Fatalf("Move funds return error: %v", err)
 	}


### PR DESCRIPTION
Line 21 is missing an '&' for the BaseSetupImpl. This gives error of: "undefined: BaseSetupImpl", when we run the command: "go test end_to_end_test.go base_test_setup.go"

Line 49 has extra '&' for the 'testSetup' variable. It gives an error of: "cannot use &testSetup (type **BaseSetupImpl) as type *BaseSetupImpl in argument to moveFunds"