### PR TITLE
Keep peer responses on errors

### DIFF
--- a/pkg/fab/peer/peerendorser.go
+++ b/pkg/fab/peer/peerendorser.go
@@ -102,11 +102,7 @@ func newPeerEndorser(endorseReq *peerEndorserRequest) (*peerEndorser, error) {
 func (p *peerEndorser) ProcessTransactionProposal(ctx reqContext.Context, request fab.ProcessProposalRequest) (*fab.TransactionProposalResponse, error) {
 	logger.Debugf("Processing proposal using endorser: %s", p.target)
 
-	proposalResponse, err := p.sendProposal(ctx, request)
-	if err != nil {
-		tpr := fab.TransactionProposalResponse{Endorser: p.target}
-		return &tpr, errors.Wrapf(err, "Transaction processing for endorser [%s]", p.target)
-	}
+	proposalResponse, peerErr := p.sendProposal(ctx, request)
 
 	chaincodeStatus, err := getChaincodeResponseStatus(proposalResponse)
 	if err != nil {
@@ -119,6 +115,11 @@ func (p *peerEndorser) ProcessTransactionProposal(ctx reqContext.Context, reques
 		ChaincodeStatus:  chaincodeStatus,
 		Status:           proposalResponse.GetResponse().Status,
 	}
+
+	if peerErr != nil {
+		return &tpr, errors.Wrapf(err, "Transaction processing for endorser [%s]", p.target)
+	}
+
 	return &tpr, nil
 }
 


### PR DESCRIPTION
When errors happen doing query or execute the invoker does not receive the responses as given by peers which may contain details about what happened or why the request was failed.

In particular we are using payload to return detailed information about some kind of business problems from chaincode.

Currently the sdk does not include those responses when returning an error.

This is a simple patch that changes the peer endorser so it always return the complete response even in the cases when the peer answered with a failure status.
