### PR TITLE
[FABG-913] Fail-fast for Discovery Service

### DIFF
--- a/pkg/fab/discovery/discovery.go
+++ b/pkg/fab/discovery/discovery.go
@@ -8,6 +8,7 @@ package discovery
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/hyperledger/fabric-protos-go/discovery"
@@ -70,18 +71,31 @@ func (c *Client) Send(ctx context.Context, req *Request, targets ...fab.PeerConf
 	var responses []Response
 	var errs error
 
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	for _, t := range targets {
 		go func(target fab.PeerConfig) {
 			defer wg.Done()
 
-			resp, err := c.send(ctx, req.r, target)
+			targetCtx, cancelTarget := context.WithCancel(reqCtx)
+			defer cancelTarget()
+
+			resp, err := c.send(targetCtx, req.r, target)
 			lock.Lock()
 			if err != nil {
-				errs = multi.Append(errs, errors.WithMessage(err, "From target: "+target.URL))
-				logger.Debugf("... got discovery error response from [%s]: %s", target.URL, err)
+				if !isContextCanceled(err) {
+					errs = multi.Append(errs, errors.WithMessage(err, "From target: "+target.URL))
+					logger.Debugf("... got discovery error response from [%s]: %s", target.URL, err)
+				} else {
+					logger.Debugf("... request to [%s] cancelled", target.URL)
+				}
 			} else {
 				responses = append(responses, &response{Response: resp, target: target.URL})
 				logger.Debugf("... got discovery response from [%s]", target.URL)
+
+				// Cancel all outstanding requests
+				cancel()
 			}
 			lock.Unlock()
 		}(t)
@@ -138,4 +152,8 @@ func newAuthInfo(ctx fabcontext.Client) (*discovery.AuthInfo, error) {
 		ClientIdentity:    identity,
 		ClientTlsCertHash: hash,
 	}, nil
+}
+
+func isContextCanceled(err error) bool {
+	return strings.Contains(err.Error(), context.Canceled.Error())
 }


### PR DESCRIPTION
When a request is sent to the Discovery Service and MaxTargets is set to > 1 then, even though a response is received from one peer, we wait for ALL other requests to complete. When a peer is down then (depending on the connection settings) this may take a long time given GRPC's retry logic.

This patch changes the logic to cancel all other outstanding requests as soon as a successful response is received.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>