### PR TITLE
[FABG-916] Evict connection in TRANSIENT_FAILURE state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/pkg/fab/comm/connector.go
+++ b/pkg/fab/comm/connector.go
@@ -129,8 +129,9 @@ func (cc *CachingConnector) DialContext(ctx context.Context, target string, opts
 	if err := cc.openConn(ctx, c); err != nil {
 		cc.lock.Lock()
 		setClosed(c)
+		cc.removeConn(c)
 		cc.lock.Unlock()
-		return nil, errors.Errorf("dialing connection timed out [%s]", target)
+		return nil, errors.WithMessagef(err, "dialing connection on target [%s]", target)
 	}
 	return c.conn, nil
 }
@@ -228,6 +229,12 @@ func waitConn(ctx context.Context, conn *grpc.ClientConn, targetState connectivi
 		state := conn.GetState()
 		if state == targetState {
 			break
+		}
+		if state == connectivity.TransientFailure {
+			// The server was probably restarted. It's better for the client to retry with a new connection rather
+			// than reusing a cached connection that's in TRANSIENT_FAILURE state since it takes much longer to
+			// recover while waiting for the state to change to READY - even if the server is up.
+			return errors.Errorf("connection is in %s", state)
 		}
 		if !conn.WaitForStateChange(ctx, state) {
 			return errors.Wrap(ctx.Err(), "waiting for connection failed")


### PR DESCRIPTION
When a peer is shut down, the connection to that peer goes into TRANSIENT_FAILURE state and we wait for it to be set to READY state. After the peer is started the connection will be in TRANSIENT_FAILURE state for several more seconds (even though the peer is up), potentially causing timeouts at the client.
With this patch, connections that are in TRANSIENT_FAIURE state are evicted from the cache. An error is immediately returned to the client so that it may retry connecting with a fresh connection.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>