### PR TITLE
[FABG-911] PKCS11 context resilience for errors

### DIFF
--- a/pkg/core/cryptosuite/common/pkcs11/contextHandle.go
+++ b/pkg/core/cryptosuite/common/pkcs11/contextHandle.go
@@ -8,7 +8,6 @@ package pkcs11
 
 import (
 	"fmt"
-
 	"sync"
 
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/sdkpatch/cachebridge"
@@ -69,6 +68,7 @@ type ContextHandle struct {
 	opts               ctxOpts
 	reloadNotification chan struct{}
 	lock               sync.RWMutex
+	recovery           bool
 }
 
 // NotifyCtxReload registers a channel to get notification when underlying mPkcs11.Ctx is recreated
@@ -82,6 +82,11 @@ func (handle *ContextHandle) OpenSession() (mPkcs11.SessionHandle, error) {
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	err := handle.isInRecovery()
+	if err != nil {
+		return 0, err
+	}
+
 	return handle.ctx.OpenSession(handle.slot, mPkcs11.CKF_SERIAL_SESSION|mPkcs11.CKF_RW_SESSION)
 }
 
@@ -94,7 +99,13 @@ func (handle *ContextHandle) Login(session mPkcs11.SessionHandle) error {
 	if handle.pin == "" {
 		return errors.New("No PIN set")
 	}
-	err := handle.ctx.Login(session, mPkcs11.CKU_USER, handle.pin)
+
+	err := handle.isInRecovery()
+	if err != nil {
+		return err
+	}
+
+	err = handle.ctx.Login(session, mPkcs11.CKU_USER, handle.pin)
 	if err != nil && err != mPkcs11.Error(mPkcs11.CKR_USER_ALREADY_LOGGED_IN) {
 		return errors.Errorf("Login failed [%s]", err)
 	}
@@ -114,9 +125,15 @@ func (handle *ContextHandle) ReturnSession(session mPkcs11.SessionHandle) {
 		return
 	}
 
-	_, e = handle.ctx.GetSessionInfo(session)
+	e = handle.isInRecovery()
 	if e != nil {
 		logger.Warnf("not returning session [%d], due to error [%s]. Discarding it", session, e)
+		return
+	}
+
+	_, e = handle.ctx.GetSessionInfo(session)
+	if e != nil {
+		logger.Debugf("not returning session [%d], due to error [%s]. Discarding it", session, e)
 		e = handle.ctx.CloseSession(session)
 		if e != nil {
 			logger.Warn("unable to close session:", e)
@@ -145,17 +162,18 @@ func (handle *ContextHandle) ReturnSession(session mPkcs11.SessionHandle) {
 //if new session is invalid recreates one after reloading ctx and re-login
 func (handle *ContextHandle) GetSession() (session mPkcs11.SessionHandle) {
 	handle.lock.RLock()
+	logger.Debugf("Total number of sessions currently in pool is %d\n", len(handle.sessions))
 	select {
 	case session = <-handle.sessions:
 		logger.Debugf("Reusing existing pkcs11 session %+v on slot %d\n", session, handle.slot)
 		handle.lock.RUnlock()
 	default:
 		handle.lock.RUnlock()
-		logger.Debug("opening a new session since cache is empty/full")
+		logger.Debug("Opening a new session since cache is empty (or completely in use)")
 		// cache is empty (or completely in use), create a new session
 		s, err := handle.OpenSession()
 		if err != nil {
-			logger.Debugf("opening a new session failed [%v], will retry %d times", err, handle.opts.openSessionRetry)
+			logger.Debugf("Opening a new session failed [%v], will retry %d times", err, handle.opts.openSessionRetry)
 			handle.lock.Lock()
 			defer handle.lock.Unlock()
 			for i := 0; i < handle.opts.openSessionRetry; i++ {
@@ -174,8 +192,8 @@ func (handle *ContextHandle) GetSession() (session mPkcs11.SessionHandle) {
 			return s
 		}
 		logger.Debugf("Created new pkcs11 session %+v on slot %d", s, handle.slot)
-		session = s
-		cachebridge.ClearSession(fmt.Sprintf("%d", session))
+		cachebridge.ClearSession(fmt.Sprintf("%d", s))
+		return s
 	}
 	return handle.validateSession(session)
 }
@@ -186,6 +204,11 @@ func (handle *ContextHandle) GetAttributeValue(session mPkcs11.SessionHandle, ob
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return nil, e
+	}
+
 	return handle.ctx.GetAttributeValue(session, objectHandle, attrs)
 }
 
@@ -194,6 +217,11 @@ func (handle *ContextHandle) SetAttributeValue(session mPkcs11.SessionHandle, ob
 
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
 
 	return handle.ctx.SetAttributeValue(session, objectHandle, attrs)
 }
@@ -209,6 +237,11 @@ func (handle *ContextHandle) GenerateKeyPair(session mPkcs11.SessionHandle, m []
 		return 0, 0, errors.Wrap(err, "failed to generate key pair")
 	}
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return 0, 0, e
+	}
+
 	return handle.ctx.GenerateKeyPair(session, m, public, private)
 }
 
@@ -218,6 +251,11 @@ func (handle *ContextHandle) GenerateKey(session mPkcs11.SessionHandle, m []*mPk
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return 0, e
+	}
+
 	return handle.ctx.GenerateKey(session, m, temp)
 }
 
@@ -226,6 +264,11 @@ func (handle *ContextHandle) FindObjectsInit(session mPkcs11.SessionHandle, temp
 
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
 
 	return handle.ctx.FindObjectsInit(session, temp)
 }
@@ -237,6 +280,11 @@ func (handle *ContextHandle) FindObjects(session mPkcs11.SessionHandle, max int)
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return nil, false, e
+	}
+
 	return handle.ctx.FindObjects(session, max)
 }
 
@@ -245,6 +293,11 @@ func (handle *ContextHandle) FindObjectsFinal(session mPkcs11.SessionHandle) err
 
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
 
 	return handle.ctx.FindObjectsFinal(session)
 }
@@ -255,6 +308,11 @@ func (handle *ContextHandle) Encrypt(session mPkcs11.SessionHandle, message []by
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return nil, e
+	}
+
 	return handle.ctx.Encrypt(session, message)
 }
 
@@ -263,6 +321,11 @@ func (handle *ContextHandle) EncryptInit(session mPkcs11.SessionHandle, m []*mPk
 
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
 
 	return handle.ctx.EncryptInit(session, m, o)
 }
@@ -273,6 +336,11 @@ func (handle *ContextHandle) DecryptInit(session mPkcs11.SessionHandle, m []*mPk
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
+
 	return handle.ctx.DecryptInit(session, m, o)
 }
 
@@ -281,6 +349,11 @@ func (handle *ContextHandle) Decrypt(session mPkcs11.SessionHandle, cypher []byt
 
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return nil, e
+	}
 
 	return handle.ctx.Decrypt(session, cypher)
 }
@@ -292,6 +365,11 @@ func (handle *ContextHandle) SignInit(session mPkcs11.SessionHandle, m []*mPkcs1
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
+
 	return handle.ctx.SignInit(session, m, o)
 }
 
@@ -300,6 +378,11 @@ func (handle *ContextHandle) SignInit(session mPkcs11.SessionHandle, m []*mPkcs1
 func (handle *ContextHandle) Sign(session mPkcs11.SessionHandle, message []byte) ([]byte, error) {
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return nil, e
+	}
 
 	return handle.ctx.Sign(session, message)
 }
@@ -311,6 +394,11 @@ func (handle *ContextHandle) VerifyInit(session mPkcs11.SessionHandle, m []*mPkc
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
+
 	return handle.ctx.VerifyInit(session, m, key)
 }
 
@@ -321,6 +409,11 @@ func (handle *ContextHandle) Verify(session mPkcs11.SessionHandle, data []byte, 
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
+
 	return handle.ctx.Verify(session, data, signature)
 }
 
@@ -328,6 +421,11 @@ func (handle *ContextHandle) Verify(session mPkcs11.SessionHandle, data []byte, 
 func (handle *ContextHandle) CreateObject(session mPkcs11.SessionHandle, temp []*mPkcs11.Attribute) (mPkcs11.ObjectHandle, error) {
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return 0, e
+	}
 
 	return handle.ctx.CreateObject(session, temp)
 }
@@ -337,6 +435,11 @@ func (handle *ContextHandle) CopyObject(sh mPkcs11.SessionHandle, o mPkcs11.Obje
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return 0, e
+	}
+
 	return handle.ctx.CopyObject(sh, o, temp)
 }
 
@@ -344,6 +447,11 @@ func (handle *ContextHandle) CopyObject(sh mPkcs11.SessionHandle, o mPkcs11.Obje
 func (handle *ContextHandle) DestroyObject(sh mPkcs11.SessionHandle, oh mPkcs11.ObjectHandle) error {
 	handle.lock.RLock()
 	defer handle.lock.RUnlock()
+
+	e := handle.isInRecovery()
+	if e != nil {
+		return e
+	}
 
 	return handle.ctx.DestroyObject(sh, oh)
 }
@@ -358,6 +466,11 @@ func (handle *ContextHandle) FindKeyPairFromSKI(session mPkcs11.SessionHandle, s
 		return nil, errors.Wrap(err, "Failed to find key pair from SKI")
 	}
 
+	e := handle.isInRecovery()
+	if e != nil {
+		return nil, e
+	}
+
 	return cachebridge.GetKeyPairFromSessionSKI(&cachebridge.KeyPairCacheKey{Mod: handle.ctx, Session: session, SKI: ski, KeyType: keyType})
 }
 
@@ -368,7 +481,22 @@ func (handle *ContextHandle) validateSession(currentSession mPkcs11.SessionHandl
 
 	handle.lock.RLock()
 
-	e := handle.detectErrorCondition(currentSession)
+	e := isEmpty(currentSession)
+	if e != nil {
+		logger.Debugf("Not validating session[%d] due to [%d], ", currentSession, e)
+		return currentSession
+	}
+
+	e = handle.isInRecovery()
+	if e != nil {
+		return 0
+	}
+
+	logger.Debugf("Validating session[%+v], for any error condition....", currentSession)
+	e = handle.detectErrorCondition(currentSession)
+	if e != nil {
+		logger.Warnf("Found error condition, while validating session [%+v], error:[%v]", currentSession, e)
+	}
 
 	switch e {
 	case errSlotIDChanged,
@@ -380,7 +508,7 @@ func (handle *ContextHandle) validateSession(currentSession mPkcs11.SessionHandl
 		mPkcs11.Error(mPkcs11.CKR_GENERAL_ERROR),
 		mPkcs11.Error(mPkcs11.CKR_USER_NOT_LOGGED_IN):
 
-		logger.Warnf("Found error condition [%s], attempting to recreate pkcs11 context and re-login....", e)
+		logger.Debugf("Found error condition [%s] for session[%+v], attempting to recreate pkcs11 context and re-login....", e, currentSession)
 
 		handle.lock.RUnlock()
 		handle.lock.Lock()
@@ -388,7 +516,8 @@ func (handle *ContextHandle) validateSession(currentSession mPkcs11.SessionHandl
 
 		newSession, err := handle.reLogin()
 		if err != nil {
-			logger.Warnf("Re-login Failed : %s,", err)
+			logger.Warnf("Failed to recover session[%v], cause: %s,", currentSession, err)
+			return 0
 		}
 		return newSession
 
@@ -398,26 +527,39 @@ func (handle *ContextHandle) validateSession(currentSession mPkcs11.SessionHandl
 		panic(fmt.Sprintf("PKCS11 Session failure: [%s]", e))
 
 	default:
+		logger.Debugf("Not an Error condition [%+v], didn't match any condition....", e)
 		handle.lock.RUnlock()
 		// default should be a valid session or valid error, return session as it is
 		return currentSession
 	}
 }
 
+// isInRecovery returns if current context handle is in recovery mode
+func (handle *ContextHandle) isInRecovery() error {
+
+	if handle.recovery {
+		logger.Debugf("Attempt to access ctx which is in recovery mode, returning error")
+		return errors.New("pkcs11 ctx is under recovery, try again later")
+	}
+
+	return nil
+}
+
 // reLogin destroys pkcs11 context and tries to re-login and returns new session
 // Note: this function isn't thread safe, recommended to use write lock for calling this function
 func (handle *ContextHandle) reLogin() (mPkcs11.SessionHandle, error) {
 
-	// dispose existing pkcs11 ctx
+	// dispose existing pkcs11 ctx (closing sessions)
 	handle.disposePKCS11Ctx()
+	logger.Debugf("Disposed ctx, Number of sessions left in pool %d\n", len(handle.sessions))
 
 	// create new context
-	newCtx := handle.createNewPKCS11Ctx()
-	if newCtx == nil {
-		logger.Warn("Failed to recreate new pkcs11 context for given library")
-		return 0, errors.New("failed to recreate new pkcs11 context for given library")
+	var err error
+	handle.ctx, err = handle.createNewPKCS11Ctx()
+	if err != nil {
+		logger.Warn("Failed to recreate new pkcs11 context for given library", err)
+		return 0, errors.WithMessage(err, "failed to recreate new pkcs11 context for given library")
 	}
-	handle.ctx = newCtx
 
 	// find slot
 	slot, found := handle.findSlot(handle.ctx)
@@ -438,15 +580,12 @@ func (handle *ContextHandle) reLogin() (mPkcs11.SessionHandle, error) {
 	// login with new session
 	err = handle.ctx.Login(newSession, mPkcs11.CKU_USER, handle.pin)
 	if err != nil && err != mPkcs11.Error(mPkcs11.CKR_USER_ALREADY_LOGGED_IN) {
-		logger.Warnf("Unable to login with new session :%d", newSession)
+		logger.Errorf("Unable to login with new session :%d, error:%v", newSession, err)
 		return 0, errors.Errorf("unable to login with new session :%d", newSession)
 	}
-
-	handle.sendNotification()
 	handle.slot = slot
-	handle.sessions = make(chan mPkcs11.SessionHandle, handle.opts.sessionCacheSize)
 
-	logger.Infof("Able to login with recreated session successfully")
+	logger.Infof("Able to re-login with recreated session[%+v] successfully", newSession)
 	return newSession, nil
 }
 
@@ -485,31 +624,42 @@ func (handle *ContextHandle) disposePKCS11Ctx() {
 
 	logger.Debugf("Disposing pkcs11 ctx for [%s, %s]", handle.lib, handle.label)
 
-	//ignore error on close all sessions
+	e := handle.isInRecovery()
+	if e != nil {
+		//already disposed
+		return
+	}
+
+	// switch on recovery mode
+	handle.recovery = true
+	// flush all sessions from pool
+	handle.sessions = make(chan mPkcs11.SessionHandle, handle.opts.sessionCacheSize)
+
+	// ignore error on close all sessions
 	err := handle.ctx.CloseAllSessions(handle.slot)
 	if err != nil {
 		logger.Warn("Unable to close session", err)
 	}
 
-	//clear cache
+	// clear cache
 	cachebridge.ClearAllSession()
 
-	//Initialize context
+	// Finalize context
 	err = handle.ctx.Finalize()
 	if err != nil {
 		logger.Warnf("unable to finalize pkcs11 ctx for [%s, %s] : %s", handle.lib, handle.label, err)
 	}
 
-	//Destroy context
+	// Destroy context
 	handle.ctx.Destroy()
 }
 
 //createNewPKCS11Ctx creates new mPkcs11.Ctx
-func (handle *ContextHandle) createNewPKCS11Ctx() *mPkcs11.Ctx {
+func (handle *ContextHandle) createNewPKCS11Ctx() (*mPkcs11.Ctx, error) {
 	newCtx := mPkcs11.New(handle.lib)
 	if newCtx == nil {
 		logger.Warn("Failed to recreate new context for given library")
-		return nil
+		return nil, errors.New("Failed to recreate new context for given library")
 	}
 
 	//initialize new context
@@ -517,11 +667,15 @@ func (handle *ContextHandle) createNewPKCS11Ctx() *mPkcs11.Ctx {
 	if err != nil {
 		if err != mPkcs11.Error(mPkcs11.CKR_CRYPTOKI_ALREADY_INITIALIZED) {
 			logger.Warn("Failed to initialize context:", err)
-			return nil
+			return nil, err
 		}
 	}
 
-	return newCtx
+	// ctx recovered
+	handle.recovery = false
+	//send notification about ctx update
+	handle.sendNotification()
+	return newCtx, nil
 }
 
 //findSlot finds slot for given pkcs11 ctx and label


### PR DESCRIPTION
- introduced recovery mode in PKCS11 context handle to avoid context
being used when it is corrupt (or in recovery)
- it helps us to reduce complexity of preserving old ctx while another
process trying to recreate/recover ctx (during HSM down time). Since
failed recovery may corrupt ctx and make it not usable (corrupted ctx
causes panic which is hard to handle/recover).

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>