### PR TITLE
[FABG-925] update codecov project target

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -6,7 +6,9 @@ coverage:
   status:
     project:
       default:
-        target: 85%
+        # this project is not currently at the desired target of 85%
+        # target: 85%
+        target: 74%
     patch:
       default:
         target: 85%


### PR DESCRIPTION
The project does not currently have the desired 85% level of code
coverage. This change updates to the current level of 74%.

Signed-off-by: Troy Ronda <troy@troyronda.com>