### PR TITLE
[FABG-930] Ignore _lifecycle namespace in endorsement handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/pkg/client/channel/invoke/selectendorsehandler.go
+++ b/pkg/client/channel/invoke/selectendorsehandler.go
@@ -23,7 +23,7 @@ import (
 var logger = logging.NewLogger("fabsdk/client")
 
 var lsccFilter = func(ccID string) bool {
-	return ccID != "lscc"
+	return ccID != "lscc" && ccID != "_lifecycle"
 }
 
 // SelectAndEndorseHandler selects endorsers according to the policies of the chaincodes in the provided invocation chain


### PR DESCRIPTION
When using Fabric 2.0, the _lifecycle namespace shows up in the endorsement response and an error is returned by the Discovery service when asking for endorsers for this namespace. This patch filters out the '_lifecycle' namespace (along with the 'lscc' namespace).

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>