### PR TITLE
[FABG-929] Use retry options from channel policy for selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/pkg/fab/default_channel_test.go
+++ b/pkg/fab/default_channel_test.go
@@ -35,6 +35,10 @@ func TestDefaultChannelWithDefaultChannelConfiguredAndNoMatchers(t *testing.T) {
 	assert.Equal(t, 3, chConfig.Policies.QueryChannelConfig.MaxTargets)
 	assert.Equal(t, 1, chConfig.Policies.Discovery.MinResponses)
 	assert.Equal(t, 3, chConfig.Policies.Discovery.MaxTargets)
+	assert.Equal(t, 2, chConfig.Policies.Discovery.RetryOpts.Attempts)
+	assert.Equal(t, 2*time.Second, chConfig.Policies.Discovery.RetryOpts.InitialBackoff)
+	assert.Equal(t, 7*time.Second, chConfig.Policies.Discovery.RetryOpts.MaxBackoff)
+	assert.Equal(t, 2, len(chConfig.Policies.Discovery.RetryOpts.RetryableCodes))
 
 	eventPolicies := chConfig.Policies.EventService
 	assert.Equalf(t, fab.BalancedStrategy, eventPolicies.ResolverStrategy, "Unexpected value for ResolverStrategy")

--- a/pkg/fab/endpointconfig.go
+++ b/pkg/fab/endpointconfig.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/multi"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/logging"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
@@ -28,6 +29,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/util/pathvar"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	grpcCodes "google.golang.org/grpc/codes"
 )
 
 var logger = logging.NewLogger("fabsdk/fab")
@@ -76,6 +78,23 @@ const (
 )
 
 var (
+	defaultDiscoveryRetryableCodes = map[status.Group][]status.Code{
+		status.GRPCTransportStatus: {
+			status.Code(grpcCodes.Unavailable),
+		},
+		status.DiscoveryServerStatus: {
+			status.QueryEndorsers,
+		},
+	}
+
+	defaultDiscoveryRetryOpts = retry.Opts{
+		Attempts:       6,
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     5 * time.Second,
+		BackoffFactor:  1.75,
+		RetryableCodes: defaultDiscoveryRetryableCodes,
+	}
+
 	defaultChannelPolicies = &ChannelPolicies{
 		QueryChannelConfig: QueryChannelConfigPolicy{
 			MaxTargets:   defaultMaxTargets,
@@ -85,7 +104,7 @@ var (
 		Discovery: DiscoveryPolicy{
 			MaxTargets:   defaultMaxTargets,
 			MinResponses: defaultMinResponses,
-			RetryOpts:    retry.Opts{},
+			RetryOpts:    defaultDiscoveryRetryOpts,
 		},
 		Selection: SelectionPolicy{
 			SortingStrategy:         BlockHeightPriority,
@@ -996,6 +1015,10 @@ func (c *EndpointConfig) loadDefaultDiscoveryPolicy(policy *fab.DiscoveryPolicy)
 
 	if policy.MinResponses == 0 {
 		policy.MinResponses = defaultMinResponses
+	}
+
+	if len(policy.RetryOpts.RetryableCodes) == 0 {
+		policy.RetryOpts.RetryableCodes = defaultDiscoveryRetryableCodes
 	}
 }
 


### PR DESCRIPTION
The retry options for the Fabric selection service are now retrieved from the Discovery channel policies which are defined in the channel config. Also added default retry options in case the config file does not define any.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>