### PR TITLE
[FABG-946] Honour Excluded Orderer in SDK Config

### DIFF
--- a/pkg/client/resmgmt/opts.go
+++ b/pkg/client/resmgmt/opts.go
@@ -89,7 +89,11 @@ func WithOrdererEndpoint(key string) RequestOption {
 
 	return func(ctx context.Client, opts *requestOptions) error {
 
-		ordererCfg, found := ctx.EndpointConfig().OrdererConfig(key)
+		ordererCfg, found, ignoreOrderer := ctx.EndpointConfig().OrdererConfig(key)
+		if ignoreOrderer {
+			return errors.Errorf("orderer url : %s is explicitly ignored by EntityMatchers config - can't add orderer", key)
+		}
+
 		if !found {
 			return errors.Errorf("orderer not found for url : %s", key)
 		}

--- a/pkg/common/providers/fab/provider.go
+++ b/pkg/common/providers/fab/provider.go
@@ -93,7 +93,7 @@ type CommManager interface {
 type EndpointConfig interface {
 	Timeout(TimeoutType) time.Duration
 	OrderersConfig() []OrdererConfig
-	OrdererConfig(nameOrURL string) (*OrdererConfig, bool)
+	OrdererConfig(nameOrURL string) (*OrdererConfig, bool, bool)
 	PeersConfig(org string) ([]PeerConfig, bool)
 	PeerConfig(nameOrURL string) (*PeerConfig, bool)
 	NetworkConfig() *NetworkConfig

--- a/pkg/common/providers/test/mockfab/mockfab.gen.go
+++ b/pkg/common/providers/test/mockfab/mockfab.gen.go
@@ -123,12 +123,13 @@ func (mr *MockEndpointConfigMockRecorder) NetworkPeers() *gomock.Call {
 }
 
 // OrdererConfig mocks base method
-func (m *MockEndpointConfig) OrdererConfig(arg0 string) (*fab.OrdererConfig, bool) {
+func (m *MockEndpointConfig) OrdererConfig(arg0 string) (*fab.OrdererConfig, bool, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OrdererConfig", arg0)
 	ret0, _ := ret[0].(*fab.OrdererConfig)
 	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
 }
 
 // OrdererConfig indicates an expected call of OrdererConfig

--- a/pkg/fab/channel/transactor_test.go
+++ b/pkg/fab/channel/transactor_test.go
@@ -11,11 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/test/mockfab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config/lookup"
@@ -203,14 +205,175 @@ func TestOrderersURLOverride(t *testing.T) {
 	user := mspmocks.NewMockSigningIdentity("test", "test")
 	ctx := mocks.NewMockContext(user)
 	ctx.SetEndpointConfig(endpointCfg)
+	// create a mock channel config for mychannel with this orderer created above
 	chConfig := mocks.NewMockChannelCfg("mychannel")
 	chConfig.MockOrderers = []string{"example.com"}
 
+	// now test orderersFromChannelCfg with above channel config (chConfig) and sdk config passed in as ctx
 	o, err := orderersFromChannelCfg(ctx, chConfig)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, o)
 	assert.Equal(t, 1, len(o), "expected one orderer from response orderers list")
 	assert.Equal(t, sampleOrdererURL, o[0].URL(), "orderer URL override from endpointconfig channels is not working as expected")
+}
+
+func TestExcludedOrdrerer(t *testing.T) {
+	sampleOrdererURL := "orderer.example.com.sample.url:100090"
+
+	//Create endpoint mockEndpoingCfg
+	configPath := filepath.Join(metadata.GetProjectPath(), "pkg", "core", "config", "testdata", "config_test.yaml")
+	configBackends, err := config.FromFile(configPath)()
+	if err != nil {
+		t.Fatal("failed to get mockEndpoingCfg backends")
+	}
+
+	networkConfig := endpointConfigEntity{}
+	err = lookup.New(configBackends...).UnmarshalKey("orderers", &networkConfig.Orderers)
+	if err != nil {
+		t.Fatal("failed to unmarshal orderer")
+	}
+
+	orderer := networkConfig.Orderers["orderer.example.com"]
+	orderer.URL = sampleOrdererURL
+	networkConfig.Orderers["orderer.example.com"] = orderer
+
+	// create a mock channel mockEndpoingCfg for mychannel with this orderer created above
+	chConfig := mocks.NewMockChannelCfg("mychannel")
+	chConfig.MockOrderers = []string{"example.com"}
+
+	backendMap := make(map[string]interface{})
+	backendMap["orderers"] = networkConfig.Orderers
+
+	backends := append([]core.ConfigBackend{}, &mocksConfig.MockConfigBackend{KeyValueMap: backendMap})
+	backends = append(backends, configBackends...)
+
+	// now try to add a second orderer to the configs
+	// 1. update channel mockEndpoingCfg with this new orderer
+	chConfig.MockOrderers = append(chConfig.MockOrderers, "example2.com")
+	// 2. update sdk configs as well
+	sampleOrderer2URL := "orderer.example2.com:9999"
+	networkConfig.Orderers["orderer.example2.com"] = fabImpl.OrdererConfig{
+		URL:         sampleOrderer2URL,
+		TLSCACerts:  networkConfig.Orderers["orderer.example.com"].TLSCACerts,  // for testing only, adding dummy cert
+		GRPCOptions: networkConfig.Orderers["orderer.example.com"].GRPCOptions, // for testing only, adding dummy cert
+	}
+	backendMap["orderers"] = networkConfig.Orderers
+
+	backendMap["channels"] = map[string]interface{}{
+		"mychannel": map[string]interface{}{
+			"orderers": []string{"orderer.example.com", "orderer.example2.com"},
+		},
+	}
+
+	backends = append([]core.ConfigBackend{}, &mocksConfig.MockConfigBackend{KeyValueMap: backendMap})
+	backends = append(backends, configBackends...)
+	endpointCfg, err := fabImpl.ConfigFromBackend(backends...)
+	if err != nil {
+		t.Fatal("failed to get endpoint mockEndpoingCfg", err)
+	}
+
+	user := mspmocks.NewMockSigningIdentity("test", "test")
+	ctx := mocks.NewMockContext(user)
+	ctx.SetEndpointConfig(endpointCfg)
+	// 3. now test orderersFromChannelCfg with updated chConfig and sdk mockEndpoingCfg (ctx)
+	o, err := orderersFromChannelCfg(ctx, chConfig)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, o)
+	assert.Equal(t, 2, len(o), "expected 2 orderers from response orderers list")
+	assert.Equal(t, sampleOrdererURL, o[0].URL(),
+		"orderer URL override from endpointconfig channels is not working as expected")
+	assert.Equal(t, sampleOrderer2URL, o[1].URL(),
+		"orderer URL override from endpointconfig channels is not working as expected")
+
+	sampleOrdererExcludedURL := "orderer.excluded.example3.com:8888"
+	// finally add a blacklisted orderer and ensure it's not returned in the configs
+
+	// first make sure it's added in the channel config
+	chConfig.MockOrderers = append(chConfig.MockOrderers, "example3.com")
+
+	// and add it's added in the networkConfig of the SDK
+	networkConfig.Orderers[sampleOrdererExcludedURL] = fabImpl.OrdererConfig{
+		URL:         sampleOrdererExcludedURL,
+		TLSCACerts:  networkConfig.Orderers["orderer.example.com"].TLSCACerts,  // for testing only, adding dummy cert
+		GRPCOptions: networkConfig.Orderers["orderer.example.com"].GRPCOptions, // for testing only, adding dummy cert
+	}
+
+	// create mock EncdpointConfig to control returned values
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockEndpoingCfg := mockfab.NewMockEndpointConfig(mockCtrl)
+
+	var orderersCfgs []fab.OrdererConfig
+	for _, v := range networkConfig.Orderers {
+		orderersCfgs = append(orderersCfgs, fab.OrdererConfig{
+			URL: v.URL,
+			GRPCOptions: v.GRPCOptions,
+		})
+	}
+
+	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
+		Orderers: []string{}})  // empty channel.Orderers SDK config, to force fetching from orderers SDK config
+	mockEndpoingCfg.EXPECT().OrdererConfig("example.com").Return(&orderersCfgs[0], true, false)
+	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(&orderersCfgs[1], true, false)
+	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true) // true means ignored
+	mockEndpoingCfg.EXPECT().OrderersConfig().Return(orderersCfgs)
+
+	ctx.SetEndpointConfig(mockEndpoingCfg)
+
+	// example3.com is marked as ignored in mockEndpointCfg above (this is equivalent to field: ignoreEndpoint:true in
+	// EntityMatchers) in SDK configs while it is added in the channel chConfig
+	o, err = orderersFromChannelCfg(ctx, chConfig)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, o)
+	assert.Equal(t, 2, len(o), "expected 2 orderers from response orderers list")
+
+	// now try with example2.com not found, to be populated from chConfig
+	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
+		Orderers: []string{}}) // empty channel.Orderers SDK config, to force fetching from orderers SDK config
+	mockEndpoingCfg.EXPECT().OrdererConfig("example.com").Return(&orderersCfgs[0], true, false)
+	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(nil, false, false)
+	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true) // true means ignored
+	mockEndpoingCfg.EXPECT().OrderersConfig().Return(orderersCfgs)
+
+	ctx.SetEndpointConfig(mockEndpoingCfg)
+
+	o, err = orderersFromChannelCfg(ctx, chConfig)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, o)
+	assert.Equal(t, 2, len(o), "expected 2 orderers from response orderers list")
+
+
+	// now retry the same previous two tests with channelConfig returning list of orderers
+	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
+		Orderers: chConfig.MockOrderers}) // read orderers from channel.Orderers SDK config
+	mockEndpoingCfg.EXPECT().OrdererConfig("example.com").Return(&orderersCfgs[0], true, false)
+	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(&orderersCfgs[1], true, false)
+	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true) // true means ignored
+
+	ctx.SetEndpointConfig(mockEndpoingCfg)
+
+	// example3.com is marked as ignored in mockEndpointCfg above (this is equivalent to field: ignoreEndpoint:true in
+	// EntityMatchers) in SDK configs while it is added in the channel chConfig
+	o, err = orderersFromChannelCfg(ctx, chConfig)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, o)
+	assert.Equal(t, 2, len(o), "expected 2 orderers from response orderers list")
+
+	// now try with example2.com not found, to be populated from chConfig
+	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
+		Orderers: chConfig.MockOrderers})  // read orderers from channel.Orderers SDK config
+	mockEndpoingCfg.EXPECT().OrdererConfig("example.com").Return(&orderersCfgs[0], true, false) // found
+	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(nil, false, false) // not found
+	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true) // excluded
+
+	ctx.SetEndpointConfig(mockEndpoingCfg)
+
+	o, err = orderersFromChannelCfg(ctx, chConfig)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, o)
+	assert.Equal(t, 1, len(o),
+		"expected 1 orderer from response orderers list since 1 orderer is not found " +
+		"and another is excluded")
 }
 
 //endpointConfigEntity contains endpoint config elements needed by endpointconfig

--- a/pkg/fab/endpointconfig_test.go
+++ b/pkg/fab/endpointconfig_test.go
@@ -112,8 +112,8 @@ func TestCAConfigFailsByNetworkConfig(t *testing.T) {
 		t.Fatalf("failed to reset network config, cause:%s", err)
 	}
 	//Testing OrdererConfig failure scenario
-	oConfig, ok := sampleEndpointConfig.OrdererConfig("peerorg1")
-	if oConfig != nil || ok {
+	oConfig, ok, ignoreOrderer := sampleEndpointConfig.OrdererConfig("peerorg1")
+	if oConfig != nil || ok || ignoreOrderer {
 		t.Fatal("Testing get OrdererConfig supposed to fail")
 	}
 
@@ -323,7 +323,7 @@ func TestOrdererConfig(t *testing.T) {
 		t.Fatal("Failed to get endpoint config from backend")
 	}
 
-	oConfig, _ := endpointConfig.OrdererConfig("invalid")
+	oConfig, _, _ := endpointConfig.OrdererConfig("invalid")
 	if oConfig != nil {
 		t.Fatal("Testing non-existing OrdererConfig failed")
 	}
@@ -392,11 +392,13 @@ func testCommonConfigOrderer(t *testing.T, expectedConfigHost string, fetchedCon
 		t.Fatal("Failed to get endpoint config from backend")
 	}
 
-	expectedConfig, ok := endpointConfig.OrdererConfig(expectedConfigHost)
+	expectedConfig, ok, ignoreOrderer := endpointConfig.OrdererConfig(expectedConfigHost)
 	assert.True(t, ok)
+	assert.False(t, ignoreOrderer)
 
-	fetchedConfig, ok = endpointConfig.OrdererConfig(fetchedConfigHost)
+	fetchedConfig, ok, ignoreOrderer = endpointConfig.OrdererConfig(fetchedConfigHost)
 	assert.True(t, ok)
+	assert.False(t, ignoreOrderer)
 
 	if expectedConfig.URL == "" {
 		t.Fatal("Url value for the host is empty")
@@ -1374,8 +1376,9 @@ func TestEntityMatchers(t *testing.T) {
 	assert.True(t, ok, "supposed to find peer config")
 	assert.NotNil(t, peerConfig, "supposed to find peer config")
 
-	ordererConfig, ok := endpointConfig.OrdererConfig("xyz.org1.example.com")
+	ordererConfig, ok, ignoreOrderer := endpointConfig.OrdererConfig("xyz.org1.example.com")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "supposed to not ignore orderer")
 	assert.NotNil(t, ordererConfig, "supposed to find orderer config")
 
 	channelConfig := endpointConfig.ChannelConfig("samplexyzchannel")
@@ -1414,8 +1417,9 @@ func TestDefaultGRPCOpts(t *testing.T) {
 	_, ok = peerConfig.GRPCOptions["allow-insecure"]
 	assert.True(t, ok)
 
-	ordererConfig, ok := endpointConfig.OrdererConfig("xyz.org1.example.com")
+	ordererConfig, ok, ignoreOrderer := endpointConfig.OrdererConfig("xyz.org1.example.com")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer)
 	assert.NotNil(t, ordererConfig, "supposed to find orderer config")
 	assert.NotEmpty(t, ordererConfig.GRPCOptions)
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))

--- a/pkg/fab/matchers_test.go
+++ b/pkg/fab/matchers_test.go
@@ -76,15 +76,17 @@ func TestAllOptionsOverride(t *testing.T) {
 	assert.Equal(t, 6, len(peerConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on URL configured in config
-	ordererConfig, ok := config.OrdererConfig("orderer.example.com:7051")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("orderer.example.com:7051")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on Name configured in config
-	ordererConfig, ok = config.OrdererConfig("orderer.example.com")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.example.com")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
@@ -124,15 +126,17 @@ func TestPartialOptionsOverride(t *testing.T) {
 	assert.Equal(t, 6, len(peerConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on URL configured in config
-	ordererConfig, ok := config.OrdererConfig("orderer.example.com:7051")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("orderer.example.com:7051")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, actualOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on Name configured in config
-	ordererConfig, ok = config.OrdererConfig("orderer.example.com")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.example.com")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, actualOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
@@ -168,15 +172,17 @@ func TestOnlyHostNameOptionsOverride(t *testing.T) {
 	assert.Equal(t, 6, len(peerConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on URL configured in config
-	ordererConfig, ok := config.OrdererConfig("orderer.example.com:7051")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("orderer.example.com:7051")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, actualOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on Name configured in config
-	ordererConfig, ok = config.OrdererConfig("orderer.example.com")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.example.com")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, actualOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
@@ -204,8 +210,9 @@ func TestURLMapping(t *testing.T) {
 	assert.Equal(t, 6, len(peerConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on URL configured in config
-	ordererConfig, ok := config.OrdererConfig("my.org.exampleX.com:1234")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("my.org.exampleX.com:1234")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
@@ -224,8 +231,9 @@ func TestURLMapping(t *testing.T) {
 	assert.Equal(t, 6, len(peerConfig.GRPCOptions))
 
 	//OrdererConfig Search Based on URL configured in config (using $ in entity matchers)
-	ordererConfig, ok = config.OrdererConfig("orderer.exampleY.com:1234")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.exampleY.com:1234")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.Equal(t, 6, len(ordererConfig.GRPCOptions))
@@ -291,8 +299,9 @@ func TestOrdererMatchersWithDefaults(t *testing.T) {
 	assert.NotNil(t, config)
 
 	//OrdererConfig Search Based on matching URL,
-	ordererConfig, ok := config.OrdererConfig("XYZ.org.example.com:1234")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("XYZ.org.example.com:1234")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.NotNil(t, ordererConfig.TLSCACert)
@@ -300,8 +309,9 @@ func TestOrdererMatchersWithDefaults(t *testing.T) {
 
 	//PeerConfig Search Based on matching URL, using regex replace pattern (unknown pattern)
 	//it shouldn't fail since default peer config will be picked for unknown mapped host
-	ordererConfig, ok = config.OrdererConfig("ordABC.replace.example.com:1234")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("ordABC.replace.example.com:1234")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, "ordABC.example.com:1234", ordererConfig.URL)
 	assert.Equal(t, "ordABC.override.com", ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.NotNil(t, ordererConfig.TLSCACert)
@@ -309,8 +319,9 @@ func TestOrdererMatchersWithDefaults(t *testing.T) {
 
 	//PeerConfig Search Based on matching URL, where mapped host is missing
 	//it shouldn't fail since default peer config will be picked for unknown mapped host
-	ordererConfig, ok = config.OrdererConfig("ordABC.missing.example.com:1234")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("ordABC.missing.example.com:1234")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.NotNil(t, ordererConfig.TLSCACert)
@@ -318,8 +329,9 @@ func TestOrdererMatchersWithDefaults(t *testing.T) {
 
 	//PeerConfig Search Based on matching URL, where non existing mapped host is used
 	//it shouldn't fail since default peer config will be picked for unknown mapped host
-	ordererConfig, ok = config.OrdererConfig("ordABC.random.example.com:1234")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("ordABC.random.example.com:1234")
 	assert.True(t, ok, "supposed to find orderer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, overridedOrdererURL, ordererConfig.URL)
 	assert.Equal(t, overridedOrdererHostNameOverride, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.NotNil(t, ordererConfig.TLSCACert)
@@ -418,8 +430,9 @@ func TestDefaultOrdererForNonExistingURL(t *testing.T) {
 	assert.NotNil(t, config)
 
 	//PeerConfig Search Based on unmatched URL, default peerconfig with searchkey as URL should be returned
-	ordererConfig, ok := config.OrdererConfig("ABC.XYZ:2222")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("ABC.XYZ:2222")
 	assert.True(t, ok, "supposed to find peer config")
+	assert.False(t, ignoreOrderer, "orderer must not be ignored")
 	assert.Equal(t, "ABC.XYZ:2222", ordererConfig.URL)
 	assert.Equal(t, nil, ordererConfig.GRPCOptions["ssl-target-name-override"])
 	assert.NotNil(t, ordererConfig.TLSCACert)
@@ -592,39 +605,47 @@ func testIgnoreEndpointOrdererSearch(t *testing.T, config fab.EndpointConfig) {
 
 	//Test if orderer excluded in orderer search by name
 
-	ordererConfig, ok := config.OrdererConfig("orderer.exclude.example.com")
+	ordererConfig, ok, ignoreOrderer:= config.OrdererConfig("orderer.exclude.example.com")
 	assert.False(t, ok)
+	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)
 
-	ordererConfig, ok = config.OrdererConfig("orderer.exclude.example.com")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.exclude.example.com")
 	assert.False(t, ok)
+	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)
 
-	ordererConfig, ok = config.OrdererConfig("orderer.example.com")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.example.com")
 	assert.True(t, ok)
+	assert.False(t, ignoreOrderer, "orderer must not be excluded")
 	assert.NotNil(t, ordererConfig)
 
-	ordererConfig, ok = config.OrdererConfig("orderer.example.com")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.example.com")
 	assert.True(t, ok)
+	assert.False(t, ignoreOrderer, "orderer must not be excluded")
 	assert.NotNil(t, ordererConfig)
 
 	//Test if orderer excluded in orderer search by URL
 
-	ordererConfig, ok = config.OrdererConfig("orderer.exclude.example.com:8050")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.exclude.example.com:8050")
 	assert.False(t, ok)
+	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)
 
-	ordererConfig, ok = config.OrdererConfig("orderer.exclude.example.com:8050")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.exclude.example.com:8050")
 	assert.False(t, ok)
+	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)
 
 	//arbitrary URLs
-	ordererConfig, ok = config.OrdererConfig("orderer.exclude.example.com:1234")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.exclude.example.com:1234")
 	assert.False(t, ok)
+	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)
 
-	ordererConfig, ok = config.OrdererConfig("orderer.exclude.example.com:4321")
+	ordererConfig, ok, ignoreOrderer = config.OrdererConfig("orderer.exclude.example.com:4321")
 	assert.False(t, ok)
+	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)
 
 }

--- a/pkg/fab/mocks/mockconfig.go
+++ b/pkg/fab/mocks/mockconfig.go
@@ -181,7 +181,7 @@ func (c *MockConfig) SecurityProviderLibPath() string {
 
 // OrderersConfig returns a list of defined orderers
 func (c *MockConfig) OrderersConfig() []fab.OrdererConfig {
-	oConfig, _ := c.OrdererConfig("")
+	oConfig, _, _ := c.OrdererConfig("")
 	return []fab.OrdererConfig{*oConfig}
 }
 
@@ -206,18 +206,18 @@ func (c *MockConfig) SetCustomRandomOrdererCfg(customRandomOrdererCfg *fab.Order
 }
 
 // OrdererConfig not implemented
-func (c *MockConfig) OrdererConfig(name string) (*fab.OrdererConfig, bool) {
+func (c *MockConfig) OrdererConfig(name string) (*fab.OrdererConfig, bool, bool) {
 	if name == "Invalid" {
-		return nil, false
+		return nil, false, false
 	}
 	if c.customOrdererCfg != nil {
-		return c.customOrdererCfg, true
+		return c.customOrdererCfg, true, false
 	}
 	oConfig := fab.OrdererConfig{
 		URL: "example.com",
 	}
 
-	return &oConfig, true
+	return &oConfig, true, false
 }
 
 // KeyStorePath ...
@@ -294,7 +294,7 @@ func (c *MockConfig) ChannelOrderers(name string) []fab.OrdererConfig {
 		return nil
 	}
 
-	oConfig, _ := c.OrdererConfig("")
+	oConfig, _, _ := c.OrdererConfig("")
 
 	return []fab.OrdererConfig{*oConfig}
 }

--- a/pkg/fab/opts.go
+++ b/pkg/fab/opts.go
@@ -49,7 +49,7 @@ type orderersConfig interface {
 
 // ordererConfig interface allows to uniquely override EndpointConfig interface's OrdererConfig() function
 type ordererConfig interface {
-	OrdererConfig(name string) (*fab.OrdererConfig, bool)
+	OrdererConfig(name string) (*fab.OrdererConfig, bool, bool)
 }
 
 // peersConfig interface allows to uniquely override EndpointConfig interface's PeersConfig() function

--- a/pkg/fab/opts_test.go
+++ b/pkg/fab/opts_test.go
@@ -236,8 +236,8 @@ func (m *mockrderersConfig) OrderersConfig() []fab.OrdererConfig {
 
 type mockOrdererConfig struct{}
 
-func (m *mockOrdererConfig) OrdererConfig(name string) (*fab.OrdererConfig, bool) {
-	return &fab.OrdererConfig{URL: "o.com", GRPCOptions: nil, TLSCACert: nil}, true
+func (m *mockOrdererConfig) OrdererConfig(name string) (*fab.OrdererConfig, bool, bool) {
+	return &fab.OrdererConfig{URL: "o.com", GRPCOptions: nil, TLSCACert: nil}, true, false
 }
 
 type mockPeersConfig struct{}

--- a/pkg/fab/orderer/orderer.go
+++ b/pkg/fab/orderer/orderer.go
@@ -165,7 +165,11 @@ func FromOrdererConfig(ordererCfg *fab.OrdererConfig) Option {
 // by name from the apiconfig.Config supplied to the constructor, and then constructs a new orderer from it
 func FromOrdererName(name string) Option {
 	return func(o *Orderer) error {
-		ordererCfg, found := o.config.OrdererConfig(name)
+		ordererCfg, found, ignoreOrderer := o.config.OrdererConfig(name)
+		if ignoreOrderer {
+			return errors.Errorf("orderer config is ignoring orderer : %s by EntityMatchers", name)
+		}
+
 		if !found {
 			return errors.Errorf("orderer config not found for orderer : %s", name)
 		}

--- a/pkg/fab/orderer/orderer_test.go
+++ b/pkg/fab/orderer/orderer_test.go
@@ -15,17 +15,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric-sdk-go/pkg/core/config/endpoint"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 
 	"github.com/golang/mock/gomock"
+	"github.com/hyperledger/fabric-protos-go/common"
+	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/test/mockfab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/core/config/endpoint"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
-	"github.com/hyperledger/fabric-protos-go/common"
-	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -522,6 +522,41 @@ func TestForGRPCErrorsWithKeepAliveOpts(t *testing.T) {
 	assert.EqualValues(t, status.ConnectionFailed, status.ToOrdererStatusCode(statusError.Code))
 	//assert.EqualValues(t, grpccodes.DeadlineExceeded, status.ToGRPCStatusCode(statusError.Code))
 	assert.Equal(t, status.OrdererClientStatus, statusError.Group)
+}
+
+func TestNewOrdererFromOrdererName(t *testing.T) {
+	t.Run("run simple FromOrdererName", func(t *testing.T){
+		_, err := New(mocks.NewMockEndpointConfig(), FromOrdererName("orderer"))
+		if err != nil {
+			t.Fatalf("Failed to get new orderer from name. Error: %s", err)
+		}
+	})
+
+	t.Run("run FromOrdererName with Ignore orderer in config", func(t *testing.T){
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockEndpoingCfg := mockfab.NewMockEndpointConfig(mockCtrl)
+
+		mockEndpoingCfg.EXPECT().OrdererConfig("orderer").Return(nil, false, true)
+
+		_, err := New(mockEndpoingCfg, FromOrdererName("orderer"))
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+	})
+
+	t.Run("run FromOrdererName with orderer not found in config", func(t *testing.T){
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockEndpoingCfg := mockfab.NewMockEndpointConfig(mockCtrl)
+
+		mockEndpoingCfg.EXPECT().OrdererConfig("orderer").Return(nil, false, false)
+
+		_, err := New(mockEndpoingCfg, FromOrdererName("orderer"))
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+	})
 }
 
 func TestNewOrdererFromConfig(t *testing.T) {


### PR DESCRIPTION
Current state of the Go SDK ignores excluding an orderer as it is found in the channel config when creating the Transactor. This patch honours removal of the excluded orderer as per the SDK config OrdererMatchers. 

Change-Id: I1cb77f854656c97a201a1c8a0600c1fa3d04ecb4
Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>

closes https://jira.hyperledger.org/browse/FABG-946