### PR TITLE
fix multi.Errors panic on nil append

### DIFF
--- a/pkg/common/errors/multi/multi.go
+++ b/pkg/common/errors/multi/multi.go
@@ -44,6 +44,9 @@ func Append(errs error, err error) error {
 	if !ok {
 		return New(errs, err)
 	}
+	if err == nil {
+		return errs
+	}
 	return append(m, err)
 }
 

--- a/pkg/common/errors/multi/multi_test.go
+++ b/pkg/common/errors/multi/multi_test.go
@@ -42,6 +42,9 @@ func TestAppend(t *testing.T) {
 	assert.Equal(t, testErr, m1[0])
 	assert.Equal(t, testErr2, m1[1])
 
+	m = Append(Errors{testErr}, nil)
+	assert.Equal(t, Errors{testErr}, m)
+
 	m = Append(Errors{testErr}, testErr2)
 	m1, ok = m.(Errors)
 	assert.True(t, ok)


### PR DESCRIPTION
This extends the nil check for multi.Errors to the Append function to make sure
nil errors do not end up in the slice, causing a panic when the error string is
generated.

I ran into this panic with the `QueryBlockByTxID` function.  The QueryBlock* series of functions lack a nil check before appending errors:
https://github.com/hyperledger/fabric-sdk-go/blob/be7b275c3fc5f1d66e908c8d73e15c0aea89b88c/pkg/fab/channel/ledger.go#L91-L94
https://github.com/hyperledger/fabric-sdk-go/blob/be7b275c3fc5f1d66e908c8d73e15c0aea89b88c/pkg/fab/channel/ledger.go#L109-L112
https://github.com/hyperledger/fabric-sdk-go/blob/be7b275c3fc5f1d66e908c8d73e15c0aea89b88c/pkg/fab/channel/ledger.go#L138-L141

The tests for these functions don't seem to be capable of handling these edge cases, but I added a test for this specific case to the `multi` test suite.  This test fails on the current master (and panics when printing the failure).

If it is preferred, I can just add some nil checks on those functions, but this seemed like a simpler, more universal solution and in the spirit of how the `New` function works:
https://github.com/hyperledger/fabric-sdk-go/blob/be7b275c3fc5f1d66e908c8d73e15c0aea89b88c/pkg/common/errors/multi/multi.go#L24-L28