### PR TITLE
[FABG-954] Cancel stream context when event client closes

### DIFF
--- a/pkg/fab/comm/streamconnection.go
+++ b/pkg/fab/comm/streamconnection.go
@@ -21,13 +21,14 @@ import (
 )
 
 // StreamProvider creates a GRPC stream
-type StreamProvider func(conn *grpc.ClientConn) (grpc.ClientStream, error)
+type StreamProvider func(conn *grpc.ClientConn) (grpc.ClientStream, func(), error)
 
 // StreamConnection manages the GRPC connection and client stream
 type StreamConnection struct {
 	*GRPCConnection
 	chConfig fab.ChannelCfg
 	stream   grpc.ClientStream
+	cancel   func()
 	lock     sync.Mutex
 }
 
@@ -38,7 +39,7 @@ func NewStreamConnection(ctx fabcontext.Client, chConfig fab.ChannelCfg, streamP
 		return nil, err
 	}
 
-	stream, err := streamProvider(conn.conn)
+	stream, cancel, err := streamProvider(conn.conn)
 	if err != nil {
 		conn.commManager.ReleaseConn(conn.conn)
 		return nil, errors.Wrapf(err, "could not create stream to %s", url)
@@ -70,6 +71,7 @@ func NewStreamConnection(ctx fabcontext.Client, chConfig fab.ChannelCfg, streamP
 		GRPCConnection: conn,
 		chConfig:       chConfig,
 		stream:         stream,
+		cancel:         cancel,
 	}, nil
 }
 
@@ -88,6 +90,9 @@ func (c *StreamConnection) Close() {
 	}
 
 	logger.Debug("Closing stream....")
+
+	c.cancel()
+
 	if err := c.stream.CloseSend(); err != nil {
 		logger.Warnf("error closing GRPC stream: %s", err)
 	}

--- a/pkg/fab/comm/streamconnection_test.go
+++ b/pkg/fab/comm/streamconnection_test.go
@@ -20,12 +20,14 @@ import (
 	"google.golang.org/grpc"
 )
 
-var testStream = func(grpcconn *grpc.ClientConn) (grpc.ClientStream, error) {
-	return pb.NewDeliverClient(grpcconn).Deliver(context.Background())
+var testStream = func(grpcconn *grpc.ClientConn) (grpc.ClientStream, func(), error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := pb.NewDeliverClient(grpcconn).Deliver(ctx)
+	return stream, cancel, err
 }
 
-var invalidStream = func(grpcconn *grpc.ClientConn) (grpc.ClientStream, error) {
-	return nil, errors.New("simulated error creating stream")
+var invalidStream = func(grpcconn *grpc.ClientConn) (grpc.ClientStream, func(), error) {
+	return nil, nil, errors.New("simulated error creating stream")
 }
 
 func TestStreamConnection(t *testing.T) {


### PR DESCRIPTION
This update ensures that the GRPC stream context is cancelled when the Deliver client connection is closed.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>