### PR TITLE
Fix empty msp, capabilities and anchor peer in ConfigValue

### DIFF
--- a/pkg/fab/chconfig/chconfig.go
+++ b/pkg/fab/chconfig/chconfig.go
@@ -517,20 +517,18 @@ func loadCapabilities(configValue *common.ConfigValue, configItems *ChannelCfg, 
 
 func loadConfigValue(configItems *ChannelCfg, key string, versionsValue *common.ConfigValue, configValue *common.ConfigValue, groupName string, org string) error {
 	versionsValue.Version = configValue.Version
+	versionsValue.Value = configValue.Value
 
 	switch key {
 	case channelConfig.AnchorPeersKey:
-		versionsValue.Value = configValue.Value
 		if err := loadAnchorPeers(configValue, configItems, org); err != nil {
 			return err
 		}
 	case channelConfig.MSPKey:
-		versionsValue.Value = configValue.Value
 		if err := loadMSPKey(configValue, configItems); err != nil {
 			return err
 		}
 	case channelConfig.CapabilitiesKey:
-		versionsValue.Value = configValue.Value
 		if err := loadCapabilities(configValue, configItems, groupName); err != nil {
 			return err
 		}

--- a/pkg/fab/chconfig/chconfig.go
+++ b/pkg/fab/chconfig/chconfig.go
@@ -520,14 +520,17 @@ func loadConfigValue(configItems *ChannelCfg, key string, versionsValue *common.
 
 	switch key {
 	case channelConfig.AnchorPeersKey:
+		versionsValue.Value = configValue.Value
 		if err := loadAnchorPeers(configValue, configItems, org); err != nil {
 			return err
 		}
 	case channelConfig.MSPKey:
+		versionsValue.Value = configValue.Value
 		if err := loadMSPKey(configValue, configItems); err != nil {
 			return err
 		}
 	case channelConfig.CapabilitiesKey:
+		versionsValue.Value = configValue.Value
 		if err := loadCapabilities(configValue, configItems, groupName); err != nil {
 			return err
 		}


### PR DESCRIPTION
Now msps, anchorPeers, capabilities are collected to separated arrays in ChConfig struct, but in `ChConfig.Versions().Channel` such data is empty.