### PR TITLE
[FABG-961] Use system cert pool when connecting to fabric-ca

### DIFF
--- a/pkg/common/providers/fab/provider.go
+++ b/pkg/common/providers/fab/provider.go
@@ -9,12 +9,12 @@ package fab
 import (
 	reqContext "context"
 	"crypto/tls"
-	"crypto/x509"
 	"time"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/options"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
+	commtls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/metrics"
 	"google.golang.org/grpc"
 )
@@ -101,7 +101,7 @@ type EndpointConfig interface {
 	ChannelConfig(name string) *ChannelEndpointConfig
 	ChannelPeers(name string) []ChannelPeer
 	ChannelOrderers(name string) []OrdererConfig
-	TLSCACertPool() CertPool
+	TLSCACertPool() commtls.CertPool
 	TLSClientCerts() []tls.Certificate
 	CryptoConfigPath() string
 }
@@ -155,16 +155,6 @@ type Providers interface {
 	InfraProvider() InfraProvider
 	EndpointConfig() EndpointConfig
 	MetricsProvider
-}
-
-// CertPool is a thread safe wrapper around the x509 standard library
-// cert pool implementation.
-type CertPool interface {
-	// Get returns the cert pool, optionally adding the provided certs
-	Get() (*x509.CertPool, error)
-	//Add allows adding certificates to CertPool
-	//Call Get() after Add() to get the updated certpool
-	Add(certs ...*x509.Certificate)
 }
 
 // MetricsProvider represents a provider of metrics.

--- a/pkg/common/providers/msp/provider.go
+++ b/pkg/common/providers/msp/provider.go
@@ -8,6 +8,7 @@ package msp
 
 import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
+	commtls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 	logApi "github.com/hyperledger/fabric-sdk-go/pkg/core/logging/api"
 )
 
@@ -29,6 +30,7 @@ type IdentityConfig interface {
 	CAServerCerts(caID string) ([][]byte, bool)
 	CAClientKey(caID string) ([]byte, bool)
 	CAClientCert(caID string) ([]byte, bool)
+	TLSCACertPool() commtls.CertPool
 	CAKeyStorePath() string
 	CredentialStorePath() string
 }

--- a/pkg/common/providers/test/mockfab/mockfab.gen.go
+++ b/pkg/common/providers/test/mockfab/mockfab.gen.go
@@ -12,6 +12,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	fab "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	tls0 "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 	metrics "github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/metrics"
 )
 
@@ -183,10 +184,10 @@ func (mr *MockEndpointConfigMockRecorder) PeersConfig(arg0 interface{}) *gomock.
 }
 
 // TLSCACertPool mocks base method
-func (m *MockEndpointConfig) TLSCACertPool() fab.CertPool {
+func (m *MockEndpointConfig) TLSCACertPool() tls0.CertPool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TLSCACertPool")
-	ret0, _ := ret[0].(fab.CertPool)
+	ret0, _ := ret[0].(tls0.CertPool)
 	return ret0
 }
 

--- a/pkg/common/providers/test/mockmsp/mockmsp.gen.go
+++ b/pkg/common/providers/test/mockmsp/mockmsp.gen.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	msp "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
+	tls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 )
 
 // MockIdentityConfig is a mock of IdentityConfig interface
@@ -134,6 +135,20 @@ func (m *MockIdentityConfig) CredentialStorePath() string {
 func (mr *MockIdentityConfigMockRecorder) CredentialStorePath() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CredentialStorePath", reflect.TypeOf((*MockIdentityConfig)(nil).CredentialStorePath))
+}
+
+// TLSCACertPool mocks base method
+func (m *MockIdentityConfig) TLSCACertPool() tls.CertPool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TLSCACertPool")
+	ret0, _ := ret[0].(tls.CertPool)
+	return ret0
+}
+
+// TLSCACertPool indicates an expected call of TLSCACertPool
+func (mr *MockIdentityConfigMockRecorder) TLSCACertPool() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLSCACertPool", reflect.TypeOf((*MockIdentityConfig)(nil).TLSCACertPool))
 }
 
 // MockIdentityManager is a mock of IdentityManager interface

--- a/pkg/core/config/comm/tls/certpool.go
+++ b/pkg/core/config/comm/tls/certpool.go
@@ -12,10 +12,19 @@ import (
 	"sync/atomic"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/logging"
-	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 )
 
 var logger = logging.NewLogger("fabsdk/core")
+
+// CertPool is a thread safe wrapper around the x509 standard library
+// cert pool implementation.
+type CertPool interface {
+	// Get returns the cert pool, optionally adding the provided certs
+	Get() (*x509.CertPool, error)
+	//Add allows adding certificates to CertPool
+	//Call Get() after Add() to get the updated certpool
+	Add(certs ...*x509.Certificate)
+}
 
 // certPool is a thread safe wrapper around the x509 standard library
 // cert pool implementation.
@@ -30,7 +39,7 @@ type certPool struct {
 }
 
 // NewCertPool new CertPool implementation
-func NewCertPool(useSystemCertPool bool) (fab.CertPool, error) {
+func NewCertPool(useSystemCertPool bool) (CertPool, error) {
 
 	c, err := loadSystemCertPool(useSystemCertPool)
 	if err != nil {

--- a/pkg/core/config/comm/tls/certpool_test.go
+++ b/pkg/core/config/comm/tls/certpool_test.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 )
 
 var goodCert = &x509.Certificate{
@@ -147,7 +145,7 @@ func TestTLSCAConfigWithMultipleCerts(t *testing.T) {
 
 }
 
-func verifyCertPoolInstance(t *testing.T, pool *x509.CertPool, fabPool fab.CertPool, numberOfCertsInPool, numberOfCerts, numberOfCertsByName, numberOfSubjects int, dirty int32) {
+func verifyCertPoolInstance(t *testing.T, pool *x509.CertPool, fabPool CertPool, numberOfCertsInPool, numberOfCerts, numberOfCertsByName, numberOfSubjects int, dirty int32) {
 	assert.NotNil(t, fabPool)
 	tlsCertPool := fabPool.(*certPool)
 	assert.Equal(t, dirty, tlsCertPool.dirty)

--- a/pkg/core/mocks/mockconfigbackend.go
+++ b/pkg/core/mocks/mockconfigbackend.go
@@ -6,6 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package mocks
 
+import (
+	"strings"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
+)
+
 //MockConfigBackend mocks config backend for unit tests
 type MockConfigBackend struct {
 	//KeyValueMap map to override CustomBackend key-values.
@@ -16,4 +22,69 @@ type MockConfigBackend struct {
 func (b *MockConfigBackend) Lookup(key string) (interface{}, bool) {
 	v, ok := b.KeyValueMap[key]
 	return v, ok
+}
+
+// Set sets a backend value
+func (b *MockConfigBackend) Set(key string, value interface{}) bool {
+	if key != "" {
+		node := b.KeyValueMap
+		ss := strings.Split(key, ".")
+		for i, s := range ss {
+			if i == len(ss)-1 {
+				node[s] = value
+				return true
+			}
+			v, ok := node[s]
+			if !ok {
+				node[s] = map[string]interface{}{}
+				node = node[s].(map[string]interface{})
+			} else {
+				node, ok = v.(map[string]interface{})
+				if !ok {
+					return false
+				}
+			}
+
+		}
+	}
+	return false
+}
+
+// Get returns a value from the backend
+func (b *MockConfigBackend) Get(key string) (interface{}, bool) {
+	if key != "" {
+		node := b.KeyValueMap
+		ss := strings.Split(key, ".")
+		for i, s := range ss {
+			v, ok := node[s]
+			if i == len(ss)-1 {
+				return v, ok
+			}
+			if !ok {
+				return nil, ok
+			}
+			node = v.(map[string]interface{})
+		}
+	}
+	return nil, false
+}
+
+// BackendFromFile returns MockConfigBackend populated from file
+func BackendFromFile(configPath string) (*MockConfigBackend, error) {
+	b, err := config.FromFile(configPath)()
+	if err != nil {
+		return nil, err
+	}
+	configBackend := b[0]
+
+	backendMap := make(map[string]interface{})
+	backendMap["client"], _ = configBackend.Lookup("client")
+	backendMap["certificateAuthorities"], _ = configBackend.Lookup("certificateAuthorities")
+	backendMap["entityMatchers"], _ = configBackend.Lookup("entityMatchers")
+	backendMap["peers"], _ = configBackend.Lookup("peers")
+	backendMap["organizations"], _ = configBackend.Lookup("organizations")
+	backendMap["orderers"], _ = configBackend.Lookup("orderers")
+	backendMap["channels"], _ = configBackend.Lookup("channels")
+
+	return &MockConfigBackend{KeyValueMap: backendMap}, nil
 }

--- a/pkg/core/mocks/mockconfigbackend_test.go
+++ b/pkg/core/mocks/mockconfigbackend_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
+)
+
+func getConfigPath() string {
+	return filepath.Join(metadata.GetProjectPath(), "pkg", "core", "config", "testdata")
+}
+
+func TestMockConfigBackend(t *testing.T) {
+
+	configPath := filepath.Join(getConfigPath(), "config_test.yaml")
+	mockBackend, err := BackendFromFile(configPath)
+	if err != nil {
+		t.Fatalf("Unexpected error reading config: %s", err)
+	}
+
+	v, ok := mockBackend.Get("client")
+	assert.True(t, ok, "!ok")
+	assert.NotNil(t, v, "client not found")
+	assert.True(t, reflect.TypeOf(v) == reflect.TypeOf(map[string]interface{}{}), "wrong type")
+
+	v, ok = mockBackend.Get("client.tlscerts.systemcertpool")
+	assert.True(t, ok, "!ok")
+	assert.True(t, reflect.TypeOf(v) == reflect.TypeOf(true), "wrong type")
+	assert.False(t, v.(bool), "wrong value")
+
+	mockBackend.Set("client.tlscerts.systemcertpool", true)
+	v, ok = mockBackend.Get("client.tlscerts.systemcertpool")
+	assert.True(t, ok, "!ok")
+	assert.True(t, reflect.TypeOf(v) == reflect.TypeOf(true), "wrong type")
+	assert.True(t, v.(bool), "wrong value")
+
+	v, ok = mockBackend.Get("some.new.value")
+	assert.False(t, ok, "should not be ok")
+	mockBackend.Set("some.new.value", "Hello World")
+	v, ok = mockBackend.Get("some.new.value")
+	assert.True(t, ok, "!ok")
+	assert.True(t, reflect.TypeOf(v) == reflect.TypeOf(""), "wrong type")
+	assert.Equal(t, "Hello World", v)
+
+}

--- a/pkg/fab/endpointconfig.go
+++ b/pkg/fab/endpointconfig.go
@@ -144,7 +144,7 @@ func ConfigFromBackend(coreBackend ...core.ConfigBackend) (fab.EndpointConfig, e
 type EndpointConfig struct {
 	backend                  *lookup.ConfigLookup
 	networkConfig            *fab.NetworkConfig
-	tlsCertPool              fab.CertPool
+	tlsCertPool              commtls.CertPool
 	entityMatchers           *entityMatchers
 	peerConfigsByOrg         map[string][]fab.PeerConfig
 	networkPeers             []fab.NetworkPeer
@@ -286,7 +286,7 @@ func (c *EndpointConfig) ChannelOrderers(name string) []fab.OrdererConfig {
 
 // TLSCACertPool returns the configured cert pool. If a certConfig
 // is provided, the certificate is added to the pool
-func (c *EndpointConfig) TLSCACertPool() fab.CertPool {
+func (c *EndpointConfig) TLSCACertPool() commtls.CertPool {
 	return c.tlsCertPool
 }
 

--- a/pkg/fab/mocks/mockconfig.go
+++ b/pkg/fab/mocks/mockconfig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/test/mockfab"
+	commtls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 	"github.com/pkg/errors"
 )
 
@@ -32,7 +33,7 @@ type MockConfig struct {
 	customPeerCfg          *fab.PeerConfig
 	customOrdererCfg       *fab.OrdererConfig
 	customRandomOrdererCfg *fab.OrdererConfig
-	CustomTLSCACertPool    fab.CertPool
+	CustomTLSCACertPool    commtls.CertPool
 	chConfig               map[string]*fab.ChannelEndpointConfig
 }
 
@@ -149,7 +150,7 @@ func (c *MockConfig) PeerConfig(nameOrURL string) (*fab.PeerConfig, bool) {
 }
 
 // TLSCACertPool ...
-func (c *MockConfig) TLSCACertPool() fab.CertPool {
+func (c *MockConfig) TLSCACertPool() commtls.CertPool {
 	if c.errorCase {
 		return &mockfab.MockCertPool{Err: errors.New("just to test error scenario")}
 	} else if c.CustomTLSCACertPool != nil {

--- a/pkg/fab/opts.go
+++ b/pkg/fab/opts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	commtls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 )
 
 // EndpointConfigOptions represents EndpointConfig interface with overridable interface functions
@@ -89,7 +90,7 @@ type channelOrderers interface {
 
 // tlsCACertPool interface allows to uniquely override EndpointConfig interface's TLSCACertPool() function
 type tlsCACertPool interface {
-	TLSCACertPool() fab.CertPool
+	TLSCACertPool() commtls.CertPool
 }
 
 // tlsClientCerts interface allows to uniquely override EndpointConfig interface's TLSClientCerts() function

--- a/pkg/fab/opts_test.go
+++ b/pkg/fab/opts_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	commtls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 )
 
 var (
@@ -284,7 +285,7 @@ func (m *mockChannelOrderers) ChannelOrderers(name string) []fab.OrdererConfig {
 
 type mockTLSCACertPool struct{}
 
-func (m *mockTLSCACertPool) TLSCACertPool() fab.CertPool {
+func (m *mockTLSCACertPool) TLSCACertPool() commtls.CertPool {
 	return nil
 }
 

--- a/pkg/msp/fabcaadapter.go
+++ b/pkg/msp/fabcaadapter.go
@@ -627,6 +627,12 @@ func createFabricCAClient(caID string, cryptoSuite core.CryptoSuite, config msp.
 		return nil, errors.Errorf("CA '%s' has no corresponding client keys in the configs", caID)
 	}
 
+	var err error
+	c.Config.TLS.TlsCertPool, err = config.TLSCACertPool().Get()
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't load configured cert pool")
+	}
+
 	//TLS flag enabled/disabled
 	c.Config.TLS.Enabled = endpoint.IsTLSEnabled(conf.URL)
 	c.Config.MSPDir = config.CAKeyStorePath()
@@ -634,7 +640,7 @@ func createFabricCAClient(caID string, cryptoSuite core.CryptoSuite, config msp.
 	//Factory opts
 	c.Config.CSP = cryptoSuite
 
-	err := c.Init()
+	err = c.Init()
 	if err != nil {
 		return nil, errors.Wrap(err, "CA Client init failed")
 	}

--- a/pkg/msp/identityconfig_test.go
+++ b/pkg/msp/identityconfig_test.go
@@ -43,25 +43,10 @@ func TestCAConfigFailsByNetworkConfig(t *testing.T) {
 
 	//Tamper 'client.network' value and use a new config to avoid conflicting with other tests
 	configPath := filepath.Join(getConfigPath(), configTestFile)
-	configBackends, err := config.FromFile(configPath)()
+	customBackend, err := mocks.BackendFromFile(configPath)
 	if err != nil {
 		t.Fatalf("Unexpected error reading config: %s", err)
 	}
-	if len(configBackends) != 1 {
-		t.Fatalf("expected 1 backend but got %d", len(configBackends))
-	}
-	configBackend := configBackends[0]
-
-	backendMap := make(map[string]interface{})
-	backendMap["client"], _ = configBackend.Lookup("client")
-	backendMap["certificateAuthorities"], _ = configBackend.Lookup("certificateAuthorities")
-	backendMap["entityMatchers"], _ = configBackend.Lookup("entityMatchers")
-	backendMap["peers"], _ = configBackend.Lookup("peers")
-	backendMap["organizations"], _ = configBackend.Lookup("organizations")
-	backendMap["orderers"], _ = configBackend.Lookup("orderers")
-	backendMap["channels"], _ = configBackend.Lookup("channels")
-
-	customBackend := &mocks.MockConfigBackend{KeyValueMap: backendMap}
 
 	identityCfg, err := ConfigFromBackend(customBackend)
 	if err != nil {
@@ -88,6 +73,62 @@ func TestCAConfigFailsByNetworkConfig(t *testing.T) {
 
 	//Testing CAConfig failure scenario
 	testCAConfigFailureScenario(sampleIdentityConfig, t)
+
+}
+
+func TestCACACertConfig(t *testing.T) {
+
+	configPath := filepath.Join(getConfigPath(), configTestFile)
+	mockBackend, err := mocks.BackendFromFile(configPath)
+	if err != nil {
+		t.Fatalf("Unexpected error reading config: %s", err)
+	}
+
+	// SystemCertPool is disabled
+	ok := mockBackend.Set("client.tlscerts.systemcertpool", false)
+	if !ok {
+		t.Fatal("Failed to set client.tlscerts.systemcertpool")
+	}
+
+	// CAs don't have defined CACert
+	casi, ok := mockBackend.Get("certificateAuthorities")
+	if !ok {
+		t.Fatal("Failed to get certificateAuthorities")
+	}
+	cas, ok := casi.(map[string]interface{})
+	if !ok {
+		t.Fatal("Wrong type")
+	}
+	for _, cai := range cas {
+		ca, ok := cai.(map[string]interface{})
+		if !ok {
+			t.Fatal("Wrong type")
+		}
+		b := mocks.MockConfigBackend{KeyValueMap: ca}
+		// remove CA cert path
+		if !b.Set("tlscacerts.path", "") {
+			t.Fatal("Failed to set tlscacerts.path")
+		}
+	}
+
+	_, err = ConfigFromBackend(mockBackend)
+	if err == nil {
+		t.Fatal("Expected error for bad config")
+	}
+	if !strings.Contains(err.Error(), "doesn't have defined tlsCACerts") {
+		t.Fatal("Wrong error for bad config")
+	}
+
+	// enable SystemCertPool, it should be sufficient for good configuration
+	ok = mockBackend.Set("client.tlscerts.systemcertpool", true)
+	if !ok {
+		t.Fatal("Failed to set client.tlscerts.systemcertpool")
+	}
+
+	_, err = ConfigFromBackend(mockBackend)
+	if err != nil {
+		t.Fatal("Expected no error for when only SystemCertPool is present")
+	}
 
 }
 

--- a/pkg/msp/opts.go
+++ b/pkg/msp/opts.go
@@ -8,6 +8,7 @@ package msp
 
 import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
+	commtls "github.com/hyperledger/fabric-sdk-go/pkg/core/config/comm/tls"
 	"github.com/pkg/errors"
 )
 
@@ -21,6 +22,7 @@ type IdentityConfigOptions struct {
 	caClientCert
 	caKeyStorePath
 	credentialStorePath
+	tlsCACertPool
 }
 
 type applier func()
@@ -62,6 +64,11 @@ type credentialStorePath interface {
 	CredentialStorePath() string
 }
 
+// tlsCACertPool interface allows to uniquely override IdentityConfig interface's TLSCACertPool() function
+type tlsCACertPool interface {
+	TLSCACertPool() commtls.CertPool
+}
+
 // BuildIdentityConfigFromOptions will return an IdentityConfig instance pre-built with Optional interfaces
 // provided in fabsdk's WithConfigIdentity(opts...) call
 func BuildIdentityConfigFromOptions(opts ...interface{}) (msp.IdentityConfig, error) {
@@ -90,6 +97,7 @@ func UpdateMissingOptsWithDefaultConfig(c *IdentityConfigOptions, d msp.Identity
 	s.set(c.caClientCert, nil, func() { c.caClientCert = d })
 	s.set(c.caKeyStorePath, nil, func() { c.caKeyStorePath = d })
 	s.set(c.credentialStorePath, nil, func() { c.credentialStorePath = d })
+	s.set(c.tlsCACertPool, nil, func() { c.tlsCACertPool = d })
 
 	return c
 }
@@ -111,6 +119,7 @@ func setIdentityConfigWithOptionInterface(c *IdentityConfigOptions, o interface{
 	s.set(c.caClientCert, func() bool { _, ok := o.(caClientCert); return ok }, func() { c.caClientCert = o.(caClientCert) })
 	s.set(c.caKeyStorePath, func() bool { _, ok := o.(caKeyStorePath); return ok }, func() { c.caKeyStorePath = o.(caKeyStorePath) })
 	s.set(c.credentialStorePath, func() bool { _, ok := o.(credentialStorePath); return ok }, func() { c.credentialStorePath = o.(credentialStorePath) })
+	s.set(c.tlsCACertPool, func() bool { _, ok := o.(tlsCACertPool); return ok }, func() { c.tlsCACertPool = o.(tlsCACertPool) })
 
 	if !s.isSet {
 		return errors.Errorf("option %#v is not a sub interface of IdentityConfig, at least one of its functions must be implemented.", o)

--- a/test/integration/e2e/configless/endpointconfig_override_test.go
+++ b/test/integration/e2e/configless/endpointconfig_override_test.go
@@ -689,7 +689,7 @@ func (m *exampleChannelOrderers) ChannelOrderers(channelName string) []fab.Order
 }
 
 type exampleTLSCACertPool struct {
-	tlsCertPool fab.CertPool
+	tlsCertPool commtls.CertPool
 }
 
 //newTLSCACertPool will create a new exampleTLSCACertPool instance with useSystemCertPool bool flag
@@ -704,7 +704,7 @@ func newTLSCACertPool(useSystemCertPool bool) *exampleTLSCACertPool {
 }
 
 // TLSCACertPool overrides EndpointConfig's TLSCACertPool function which will add the list of cert args to the cert pool and return it
-func (m *exampleTLSCACertPool) TLSCACertPool() fab.CertPool {
+func (m *exampleTLSCACertPool) TLSCACertPool() commtls.CertPool {
 	return m.tlsCertPool
 }
 


### PR DESCRIPTION
When client.tlsCerts.systemCertPool is set to true,
TLS connections to fabric-ca instances now use system
cert pool. There is no need to have tlsCACerts.path
defined in CAs' configurations in that case.

Signed-off-by: Aleksandar Likic <aleksandar.likic@securekey.com>