### PR TITLE
[FABG-959] Unable to specify empty affiliation

### DIFF
--- a/pkg/client/msp/client_test.go
+++ b/pkg/client/msp/client_test.go
@@ -352,10 +352,10 @@ func TestCreateIdentityFailure(t *testing.T) {
 		t.Fatalf("failed to create CA client: %s", err)
 	}
 
-	// Missing required affiliation
-	_, err = c.CreateIdentity(&IdentityRequest{ID: "123"})
-	if err == nil || !strings.Contains(err.Error(), "ID and affiliation are required") {
-		t.Fatalf("Should have failed to create identity due to missing affiliation: %s", err)
+	// Missing required ID
+	_, err = c.CreateIdentity(&IdentityRequest{})
+	if err == nil || !strings.Contains(err.Error(), "ID is required") {
+		t.Fatalf("Should have failed to create identity due to missing ID: %s", err)
 	}
 
 }
@@ -371,7 +371,7 @@ func TestModifyIdentityFailure(t *testing.T) {
 
 	// Missing required ID
 	_, err = c.ModifyIdentity(&IdentityRequest{Affiliation: "org2", Secret: "top-secret", Attributes: []Attribute{{Name: "attName1", Value: "attValue1"}}})
-	if err == nil || !strings.Contains(err.Error(), "ID and affiliation are required") {
+	if err == nil || !strings.Contains(err.Error(), "ID is required") {
 		t.Fatalf("Should have failed to update identity due to missing id: %s", err)
 	}
 

--- a/pkg/msp/api/api.go
+++ b/pkg/msp/api/api.go
@@ -155,7 +155,7 @@ type IdentityRequest struct {
 	// The enrollment ID which uniquely identifies an identity (required)
 	ID string
 
-	// The identity's affiliation (required)
+	// The identity's affiliation
 	Affiliation string
 
 	// Array of attributes to assign to the user

--- a/pkg/msp/caclient.go
+++ b/pkg/msp/caclient.go
@@ -168,9 +168,9 @@ func (c *CAClientImpl) CreateIdentity(request *api.IdentityRequest) (*api.Identi
 		return nil, errors.New("must provide identity request")
 	}
 
-	// Checke required parameters (ID and affiliation)
-	if request.ID == "" || request.Affiliation == "" {
-		return nil, errors.New("ID and affiliation are required")
+	// Check required parameters (ID)
+	if request.ID == "" {
+		return nil, errors.New("ID is required")
 	}
 
 	registrar, err := c.getRegistrar(c.registrar.EnrollID, c.registrar.EnrollSecret)
@@ -197,9 +197,9 @@ func (c *CAClientImpl) ModifyIdentity(request *api.IdentityRequest) (*api.Identi
 		return nil, errors.New("must provide identity request")
 	}
 
-	// Checke required parameters (ID and affiliation)
-	if request.ID == "" || request.Affiliation == "" {
-		return nil, errors.New("ID and affiliation are required")
+	// Check required parameters (ID)
+	if request.ID == "" {
+		return nil, errors.New("ID is required")
 	}
 
 	registrar, err := c.getRegistrar(c.registrar.EnrollID, c.registrar.EnrollSecret)
@@ -226,7 +226,7 @@ func (c *CAClientImpl) RemoveIdentity(request *api.RemoveIdentityRequest) (*api.
 		return nil, errors.New("must provide remove identity request")
 	}
 
-	// Checke required parameters (ID)
+	// Check required parameters (ID)
 	if request.ID == "" {
 		return nil, errors.New("ID is required")
 	}
@@ -252,7 +252,7 @@ func (c *CAClientImpl) GetIdentity(id, caname string) (*api.IdentityResponse, er
 		return nil, fmt.Errorf("no CAs configured for organization: %s", c.orgName)
 	}
 
-	// Checke required parameters (ID and affiliation)
+	// Check required parameters (ID and affiliation)
 	if id == "" {
 		return nil, errors.New("id is required")
 	}
@@ -389,7 +389,7 @@ func (c *CAClientImpl) GetAffiliation(affiliation, caname string) (*api.Affiliat
 		return nil, fmt.Errorf("no CAs configured for organization: %s", c.orgName)
 	}
 
-	// Checke required parameters (affiliation)
+	// Check required parameters (affiliation)
 	if affiliation == "" {
 		return nil, errors.New("affiliation is required")
 	}
@@ -426,7 +426,7 @@ func (c *CAClientImpl) AddAffiliation(request *api.AffiliationRequest) (*api.Aff
 		return nil, errors.New("must provide affiliation request")
 	}
 
-	// Checke required parameters (Name)
+	// Check required parameters (Name)
 	if request.Name == "" {
 		return nil, errors.New("Name is required")
 	}
@@ -449,7 +449,7 @@ func (c *CAClientImpl) ModifyAffiliation(request *api.ModifyAffiliationRequest) 
 		return nil, errors.New("must provide affiliation request")
 	}
 
-	// Checke required parameters (Name and NewName)
+	// Check required parameters (Name and NewName)
 	if request.Name == "" || request.NewName == "" {
 		return nil, errors.New("Name and NewName are required")
 	}
@@ -472,7 +472,7 @@ func (c *CAClientImpl) RemoveAffiliation(request *api.AffiliationRequest) (*api.
 		return nil, errors.New("must provide remove affiliation request")
 	}
 
-	// Checke required parameters (Name)
+	// Check required parameters (Name)
 	if request.Name == "" {
 		return nil, errors.New("Name is required")
 	}

--- a/pkg/msp/caclient_test.go
+++ b/pkg/msp/caclient_test.go
@@ -221,12 +221,7 @@ func TestCreateIdentity(t *testing.T) {
 
 	// Create without required parameters
 	_, err = f.caClient.CreateIdentity(&api.IdentityRequest{Affiliation: "Org1"})
-	if err == nil || !strings.Contains(err.Error(), "ID and affiliation are required") {
-		t.Fatal("Expected error due to missing required parameters")
-	}
-
-	_, err = f.caClient.CreateIdentity(&api.IdentityRequest{ID: "Some name"})
-	if err == nil || !strings.Contains(err.Error(), "ID and affiliation are required") {
+	if err == nil || !strings.Contains(err.Error(), "ID is required") {
 		t.Fatal("Expected error due to missing required parameters")
 	}
 
@@ -235,6 +230,15 @@ func TestCreateIdentity(t *testing.T) {
 	attributes = append(attributes, api.Attribute{Name: "test1", Value: "test2"})
 	attributes = append(attributes, api.Attribute{Name: "test2", Value: "test3"})
 	identity, err := f.caClient.CreateIdentity(&api.IdentityRequest{ID: "test", Affiliation: "test", Attributes: attributes})
+	if err != nil {
+		t.Fatalf("create identity return error %s", err)
+	}
+	if identity.Secret != "top-secret" {
+		t.Fatalf("create identity returned wrong value %s", identity.Secret)
+	}
+
+	// Create identity with ID only
+	identity, err = f.caClient.CreateIdentity(&api.IdentityRequest{ID: "test1"})
 	if err != nil {
 		t.Fatalf("create identity return error %s", err)
 	}
@@ -258,17 +262,21 @@ func TestModifyIdentity(t *testing.T) {
 
 	// Update without required parameters
 	_, err = f.caClient.ModifyIdentity(&api.IdentityRequest{Affiliation: "Org1"})
-	if err == nil || !strings.Contains(err.Error(), "ID and affiliation are required") {
-		t.Fatal("Expected error due to missing required parameters")
-	}
-
-	_, err = f.caClient.ModifyIdentity(&api.IdentityRequest{ID: "Some name"})
-	if err == nil || !strings.Contains(err.Error(), "ID and affiliation are required") {
+	if err == nil || !strings.Contains(err.Error(), "ID is required") {
 		t.Fatal("Expected error due to missing required parameters")
 	}
 
 	// Update identity with valid request
 	identity, err := f.caClient.ModifyIdentity(&api.IdentityRequest{ID: "123", Affiliation: "org2", Secret: "new-top-secret"})
+	if err != nil {
+		t.Fatalf("update identity return error %s", err)
+	}
+	if identity.Secret != "new-top-secret" {
+		t.Fatalf("update identity returned wrong value: %s", identity.Secret)
+	}
+
+	// Update identity without affiliation
+	identity, err = f.caClient.ModifyIdentity(&api.IdentityRequest{ID: "123", Secret: "new-top-secret"})
 	if err != nil {
 		t.Fatalf("update identity return error %s", err)
 	}


### PR DESCRIPTION
Fixed a bug which required optional affiliation to be
provided when creating/modifying identities.

Signed-off-by: Aleksandar Likic <aleksandar.likic@securekey.com>