### PR TITLE
FABG-966 Add 2-arg form of getContract

### DIFF
--- a/pkg/gateway/contract.go
+++ b/pkg/gateway/contract.go
@@ -26,7 +26,11 @@ func newContract(network *Network, chaincodeID string, name string) *Contract {
 
 // Name returns the name of the smart contract
 func (c *Contract) Name() string {
-	return c.chaincodeID
+	qualifiedName := c.chaincodeID
+	if len(c.name) != 0 {
+		qualifiedName += ":" + c.name
+	}
+	return qualifiedName
 }
 
 // EvaluateTransaction will evaluate a transaction function and return its results.

--- a/pkg/gateway/contract_test.go
+++ b/pkg/gateway/contract_test.go
@@ -29,8 +29,33 @@ func TestCreateTransaction(t *testing.T) {
 		t.Fatalf("Failed to create transaction: %s", err)
 	}
 
-	name := txn.name
+	name := txn.request.Fcn
 	if name != "txn1" {
+		t.Fatalf("Incorrect transaction name: %s", name)
+	}
+}
+
+func TestCreateTransactionNamespaced(t *testing.T) {
+	c := mockChannelProvider("mychannel")
+
+	gw := &Gateway{}
+
+	nw, err := newNetwork(gw, c)
+
+	if err != nil {
+		t.Fatalf("Failed to create network: %s", err)
+	}
+
+	contr := nw.GetContractWithName("contract1", "class1")
+
+	txn, err := contr.CreateTransaction("txn1")
+
+	if err != nil {
+		t.Fatalf("Failed to create transaction: %s", err)
+	}
+
+	name := txn.request.Fcn
+	if name != "class1:txn1" {
 		t.Fatalf("Incorrect transaction name: %s", name)
 	}
 }

--- a/pkg/gateway/network.go
+++ b/pkg/gateway/network.go
@@ -58,12 +58,26 @@ func (n *Network) Name() string {
 
 // GetContract returns instance of a smart contract on the current network.
 //  Parameters:
-//  name is the name of the smart contract
+//  chaincodeID is the name of the chaincode that contains the smart contract
 //
 //  Returns:
 //  A Contract object representing the smart contract
 func (n *Network) GetContract(chaincodeID string) *Contract {
 	return newContract(n, chaincodeID, "")
+}
+
+// GetContractWithName returns instance of a smart contract on the current network.
+// If the chaincode instance contains more
+// than one smart contract class (available using the latest contract programming model), then an
+// individual class can be selected.
+//  Parameters:
+//  chaincodeID is the name of the chaincode that contains the smart contract
+//  name is the class name of the smart contract within the chaincode.
+//
+//  Returns:
+//  A Contract object representing the smart contract
+func (n *Network) GetContractWithName(chaincodeID string, name string) *Contract {
+	return newContract(n, chaincodeID, name)
 }
 
 // RegisterBlockEvent registers for block events. Unregister must be called when the registration is no longer needed.

--- a/pkg/gateway/network_test.go
+++ b/pkg/gateway/network_test.go
@@ -44,7 +44,26 @@ func TestGetContract(t *testing.T) {
 	name := contr.Name()
 
 	if name != "contract1" {
-		t.Fatalf("Incorrect contract name: %s", err)
+		t.Fatalf("Incorrect contract name: %s", name)
+	}
+}
+
+func TestGetContractWithName(t *testing.T) {
+	c := mockChannelProvider("mychannel")
+
+	gw := &Gateway{}
+
+	nw, err := newNetwork(gw, c)
+
+	if err != nil {
+		t.Fatalf("Failed to create network: %s", err)
+	}
+
+	contr := nw.GetContractWithName("contract1", "class1")
+	name := contr.Name()
+
+	if name != "contract1:class1" {
+		t.Fatalf("Incorrect contract name: %s", name)
 	}
 }
 
@@ -52,7 +71,7 @@ func TestBlockEvent(t *testing.T) {
 
 	gw := &Gateway{
 		options: &gatewayOptions{
-			Timeout:   defaultTimeout,
+			Timeout: defaultTimeout,
 		},
 	}
 
@@ -76,7 +95,7 @@ func TestFilteredBlocktEvent(t *testing.T) {
 
 	gw := &Gateway{
 		options: &gatewayOptions{
-			Timeout:   defaultTimeout,
+			Timeout: defaultTimeout,
 		},
 	}
 

--- a/pkg/gateway/transaction.go
+++ b/pkg/gateway/transaction.go
@@ -24,7 +24,6 @@ import (
 // Instances of this class are stateful. A new instance <strong>must</strong>
 // be created for each transaction invocation.
 type Transaction struct {
-	name           string
 	contract       *Contract
 	request        *channel.Request
 	endorsingPeers []string
@@ -35,10 +34,13 @@ type Transaction struct {
 type TransactionOption = func(*Transaction) error
 
 func newTransaction(name string, contract *Contract, options ...TransactionOption) (*Transaction, error) {
+	qname := name
+	if len(contract.name) > 0 {
+		qname = contract.name + ":" + name
+	}
 	txn := &Transaction{
-		name:     name,
 		contract: contract,
-		request:  &channel.Request{ChaincodeID: contract.chaincodeID, Fcn: name},
+		request:  &channel.Request{ChaincodeID: contract.chaincodeID, Fcn: qname},
 	}
 
 	for _, option := range options {


### PR DESCRIPTION
This was missed from the pkg/gateway implementation.
The 2-argument form of getContract supports multiple contract classes in a chaincode instance.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>