### PR TITLE
Fix the Ability to Override CredentialStorePath

### DIFF
--- a/pkg/fabsdk/factory/defmsp/mspfactory.go
+++ b/pkg/fabsdk/factory/defmsp/mspfactory.go
@@ -28,22 +28,20 @@ func NewProviderFactory() *ProviderFactory {
 
 // CreateUserStore creates a UserStore using the SDK's default implementation
 func (f *ProviderFactory) CreateUserStore(config msp.IdentityConfig) (msp.UserStore, error) {
-
-	stateStorePath := config.Client().CredentialStore.Path
+	stateStorePath := config.CredentialStorePath()
 
 	var userStore msp.UserStore
-
 	if stateStorePath == "" {
-		userStore = mspimpl.NewMemoryUserStore()
-	} else {
-		stateStore, err := kvs.New(&kvs.FileKeyValueStoreOptions{Path: stateStorePath})
-		if err != nil {
-			return nil, errors.WithMessage(err, "CreateNewFileKeyValueStore failed")
-		}
-		userStore, err = mspimpl.NewCertFileUserStore1(stateStore)
-		if err != nil {
-			return nil, errors.Wrapf(err, "creating a user store failed")
-		}
+		return mspimpl.NewMemoryUserStore(), nil
+	}
+
+	stateStore, err := kvs.New(&kvs.FileKeyValueStoreOptions{Path: stateStorePath})
+	if err != nil {
+		return nil, errors.WithMessage(err, "CreateNewFileKeyValueStore failed")
+	}
+	userStore, err = mspimpl.NewCertFileUserStore1(stateStore)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating a user store failed")
 	}
 
 	return userStore, nil

--- a/pkg/fabsdk/factory/defmsp/mspfactory_test.go
+++ b/pkg/fabsdk/factory/defmsp/mspfactory_test.go
@@ -42,19 +42,12 @@ func TestCreateUserStore(t *testing.T) {
 }
 
 func newMockUserStore(t *testing.T) msp.UserStore {
-	factory := NewProviderFactory()
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockConfig := mockmsp.NewMockIdentityConfig(mockCtrl)
+	mockConfig.EXPECT().CredentialStorePath().Return("/tmp/fabsdkgo_test/store")
 
-	mockClientConfig := msp.ClientConfig{
-		CredentialStore: msp.CredentialStoreType{
-			Path: "/tmp/fabsdkgo_test/store",
-		},
-	}
-	mockConfig.EXPECT().Client().Return(&mockClientConfig)
-
+	factory := NewProviderFactory()
 	userStore, err := factory.CreateUserStore(mockConfig)
 	if err != nil {
 		t.Fatalf("Unexpected error creating user store %s", err)
@@ -64,7 +57,6 @@ func newMockUserStore(t *testing.T) msp.UserStore {
 
 func TestCreateUserStoreByConfig(t *testing.T) {
 	userStore := newMockUserStore(t)
-
 	_, ok := userStore.(*mspimpl.CertFileUserStore)
 	if !ok {
 		t.Fatal("Unexpected user store created")
@@ -72,15 +64,12 @@ func TestCreateUserStoreByConfig(t *testing.T) {
 }
 
 func TestCreateUserStoreEmptyConfig(t *testing.T) {
-	factory := NewProviderFactory()
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockConfig := mockmsp.NewMockIdentityConfig(mockCtrl)
+	mockConfig.EXPECT().CredentialStorePath().Return("")
 
-	mockClientConfig := msp.ClientConfig{}
-	mockConfig.EXPECT().Client().Return(&mockClientConfig)
-
+	factory := NewProviderFactory()
 	_, err := factory.CreateUserStore(mockConfig)
 	if err != nil {
 		t.Fatal("Expected user store created")
@@ -88,15 +77,12 @@ func TestCreateUserStoreEmptyConfig(t *testing.T) {
 }
 
 func TestCreateUserStoreFailConfig(t *testing.T) {
-	factory := NewProviderFactory()
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockConfig := mockmsp.NewMockIdentityConfig(mockCtrl)
+	mockConfig.EXPECT().CredentialStorePath().Return("")
 
-	mockClientConfig := msp.ClientConfig{}
-	mockConfig.EXPECT().Client().Return(&mockClientConfig)
-
+	factory := NewProviderFactory()
 	_, err := factory.CreateUserStore(mockConfig)
 	if err != nil {
 		t.Fatal("Expected user store created")


### PR DESCRIPTION
The existing implementation pulls the value from the struct directly initialized on the client by the config file. If a user overrides the CredentialStorePath it does not supersede the value defined in client.config.credentialStore.Path. Moreover, if a user performs a configless configuration of the SDK where there is no configfile, the value is read in as "", and an inMemoryStore is used as opposed to the expected override.

This change ensures the overridden value supersedes the config value but retains the config value if no override is passed.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>