### PR TITLE
[FABG-983] fix sdk can`t found private key by file ski number

### DIFF
--- a/pkg/fab/keyvaluestore/filekeyvaluestore.go
+++ b/pkg/fab/keyvaluestore/filekeyvaluestore.go
@@ -114,7 +114,10 @@ func (fkvs *FileKeyValueStore) Load(key interface{}) (interface{}, error) {
 		return nil, err
 	}
 	if _, err1 := os.Stat(file); os.IsNotExist(err1) {
-		return nil, core.ErrKeyValueNotFound
+		file = filepath.Join(filepath.Dir(file), "priv_sk")
+		if _, err1 := os.Stat(file); os.IsNotExist(err1) {
+			return nil, core.ErrKeyValueNotFound
+		}
 	}
 	bytes, err := ioutil.ReadFile(file) // nolint: gas
 	if err != nil {


### PR DESCRIPTION
Fix [FABG-983]  sdk can`t found private key by file ski number by fabric-sdk-go master connect fabric 2.1 network and the crypto-config by cryptogen 2.1.0 version gen, the error msg that Key with SKI 097471ca42d6e900fd7ce3cb8ff679ab3ea3eef37d4107f0b0938db15a83ced5 not found in keystore,

Signed-off-by: Yunfeng Zou <zouyunfeng@peersafe.cn>