### PR TITLE
[FABG-988] Rename cauthdsl to policydsl

### DIFF
--- a/internal/github.com/hyperledger/fabric/common/policydsl/policydsl_builder.go
+++ b/internal/github.com/hyperledger/fabric/common/policydsl/policydsl_builder.go
@@ -8,7 +8,7 @@ Notice: This file has been modified for Hyperledger Fabric SDK Go usage.
 Please review third_party pinning scripts and patches for more details.
 */
 
-package cauthdsl
+package policydsl
 
 import (
 	"sort"

--- a/internal/github.com/hyperledger/fabric/common/policydsl/policyparser.go
+++ b/internal/github.com/hyperledger/fabric/common/policydsl/policyparser.go
@@ -8,7 +8,7 @@ Notice: This file has been modified for Hyperledger Fabric SDK Go usage.
 Please review third_party pinning scripts and patches for more details.
 */
 
-package cauthdsl
+package policydsl
 
 import (
 	"fmt"

--- a/internal/github.com/hyperledger/fabric/sdkinternal/configtxgen/encoder/encoder.go
+++ b/internal/github.com/hyperledger/fabric/sdkinternal/configtxgen/encoder/encoder.go
@@ -14,10 +14,10 @@ import (
 	"github.com/gogo/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
-	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/cauthdsl"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/genesis"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/policies"
+	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/util"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/protoutil"
@@ -99,7 +99,7 @@ func AddPolicies(cg *cb.ConfigGroup, policyMap map[string]*genesisconfig.Policy,
 				},
 			}
 		case SignaturePolicyType:
-			sp, err := cauthdsl.FromString(policy.Rule)
+			sp, err := policydsl.FromString(policy.Rule)
 			if err != nil {
 				return errors.Wrapf(err, "invalid signature policy rule '%s'", policy.Rule)
 			}
@@ -345,7 +345,7 @@ func NewConsortiumsGroup(conf map[string]*genesisconfig.Consortium) (*cb.ConfigG
 	consortiumsGroup := protoutil.NewConfigGroup()
 	// This policy is not referenced anywhere, it is only used as part of the implicit meta policy rule at the channel level, so this setting
 	// effectively degrades control of the ordering system channel to the ordering admins
-	addPolicy(consortiumsGroup, policies.SignaturePolicy(channelconfig.AdminsPolicyKey, cauthdsl.AcceptAllPolicy), ordererAdminsPolicyName)
+	addPolicy(consortiumsGroup, policies.SignaturePolicy(channelconfig.AdminsPolicyKey, policydsl.AcceptAllPolicy), ordererAdminsPolicyName)
 
 	for consortiumName, consortium := range conf {
 		var err error

--- a/pkg/client/common/selection/dynamicselection/pgresolver/pgresolver_test.go
+++ b/pkg/client/common/selection/dynamicselection/pgresolver/pgresolver_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	mocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	common "github.com/hyperledger/fabric-protos-go/common"
@@ -103,7 +103,7 @@ func TestPeerGroupResolverPolicy1(t *testing.T) {
 
 func TestPeerGroupResolverAcceptAllPolicy(t *testing.T) {
 
-	sigPolicyEnv := cauthdsl.AcceptAllPolicy
+	sigPolicyEnv := policydsl.AcceptAllPolicy
 
 	expected := []PeerGroup{
 		pg(p1), pg(p2), pg(p3), pg(p4), pg(p5), pg(p6),

--- a/pkg/client/resmgmt/example_test.go
+++ b/pkg/client/resmgmt/example_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/hyperledger/fabric-protos-go/common"
-	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	sdkCtx "github.com/hyperledger/fabric-sdk-go/pkg/context"
@@ -63,7 +63,7 @@ func Example() {
 	}
 
 	// Instantiate example chaincode on channel 'mychannel'
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	instantiateReq := InstantiateCCRequest{Name: "ExampleCC", Version: "v0", Path: "path", Policy: ccPolicy}
 	_, err = c.InstantiateCC("mychannel", instantiateReq, WithTargets(peer))
 	if err != nil {
@@ -172,7 +172,7 @@ func ExampleWithTargetFilter() {
 		fmt.Println("failed to create client")
 	}
 
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	req := InstantiateCCRequest{Name: "ExampleCC", Version: "v0", Path: "path", Policy: ccPolicy}
 
 	resp, err := c.InstantiateCC("mychannel", req, WithTargetFilter(&urlTargetFilter{url: "http://peer1.com"}))
@@ -291,7 +291,7 @@ func ExampleClient_InstantiateCC() {
 		fmt.Println("failed to create client")
 	}
 
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	req := InstantiateCCRequest{Name: "ExampleCC", Version: "v0", Path: "path", Policy: ccPolicy}
 
 	resp, err := c.InstantiateCC("mychannel", req)
@@ -315,7 +315,7 @@ func ExampleClient_UpgradeCC() {
 		fmt.Println("failed to create client")
 	}
 
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	req := UpgradeCCRequest{Name: "ExampleCC", Version: "v1", Path: "path", Policy: ccPolicy}
 
 	resp, err := c.UpgradeCC("mychannel", req, WithTargets(mockPeer()))

--- a/pkg/client/resmgmt/resmgmt_test.go
+++ b/pkg/client/resmgmt/resmgmt_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
-	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
@@ -815,7 +815,7 @@ func TestInstantiateCCWithDifferentMSP(t *testing.T) {
 	rc := setupResMgmtClient(t, ctx)
 
 	// Valid request
-	ccPolicy := cauthdsl.SignedByMspMember("otherMSP")
+	ccPolicy := policydsl.SignedByMspMember("otherMSP")
 	req := InstantiateCCRequest{Name: "name", Version: "version", Path: "path", Policy: ccPolicy}
 
 	// Test filter only provided (filter rejects discovery service peer msp)
@@ -836,7 +836,7 @@ func TestInstantiateCCWithOpts(t *testing.T) {
 	rc := setupDefaultResMgmtClient(t)
 
 	// Valid request
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	req := InstantiateCCRequest{Name: "name", Version: "version", Path: "path", Policy: ccPolicy}
 
 	// Setup targets
@@ -908,7 +908,7 @@ func TestUpgradeCCWithDifferentMSP(t *testing.T) {
 	rc := setupResMgmtClient(t, ctx)
 
 	// Valid request
-	ccPolicy := cauthdsl.SignedByMspMember("otherMSP")
+	ccPolicy := policydsl.SignedByMspMember("otherMSP")
 	req := UpgradeCCRequest{Name: "name", Version: "version", Path: "path", Policy: ccPolicy}
 
 	// Test filter only provided (filter rejects discovery service peer msp)
@@ -929,7 +929,7 @@ func TestUpgradeCCWithOpts(t *testing.T) {
 	rc := setupDefaultResMgmtClient(t)
 
 	// Valid request
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	req := UpgradeCCRequest{Name: "name", Version: "version", Path: "path", Policy: ccPolicy}
 
 	// Setup targets
@@ -966,7 +966,7 @@ func TestCCProposal(t *testing.T) {
 
 	rc := setupResMgmtClient(t, ctx)
 
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	instantiateReq := InstantiateCCRequest{Name: "name", Version: "version", Path: "path", Policy: ccPolicy}
 
 	// Test invalid function (only 'instatiate' and 'upgrade' are supported)
@@ -1614,7 +1614,7 @@ func TestGetConfigSignaturesFromIdentities(t *testing.T) {
 
 func TestCheckRequiredCCProposalParams(t *testing.T) {
 	// Valid request
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	req := InstantiateCCRequest{Name: "name", Version: "version", Path: "path", Policy: ccPolicy}
 
 	// Test empty channel lang

--- a/scripts/third_party_pins/fabric/apply_fabric_common_utils.sh
+++ b/scripts/third_party_pins/fabric/apply_fabric_common_utils.sh
@@ -17,8 +17,9 @@ cp -R ${TMP_PROJECT_PATH} ${PATCH_PROJECT_PATH}
 declare TMP_PROJECT_PATH=${PATCH_PROJECT_PATH}
 
 declare -a FILES=(
-        "common/cauthdsl/cauthdsl_builder.go"
-        "common/cauthdsl/policyparser.go"
+        #renamed in Fabric v2 stream
+        #"common/policydsl/policydsl_builder.go"
+        #"common/policydsl/policyparser.go"
         "core/common/ccprovider/ccprovider.go"
         "core/common/ccprovider/cdspackage.go"
         "core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go"

--- a/test/integration/base_test_setup.go
+++ b/test/integration/base_test_setup.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/pkg/util/test"
 	"github.com/hyperledger/fabric-sdk-go/test/metadata"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -307,7 +307,7 @@ func InstallChaincode(resMgmt *resmgmt.Client, ccPkg *resource.CCPackage, ccPath
 
 // InstantiateChaincode instantiates the given chaincode to the given channel
 func InstantiateChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVersion string, ccPolicyStr string, args [][]byte, collConfigs ...*pb.CollectionConfig) (resmgmt.InstantiateCCResponse, error) {
-	ccPolicy, err := cauthdsl.FromString(ccPolicyStr)
+	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return resmgmt.InstantiateCCResponse{}, errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
 	}
@@ -328,7 +328,7 @@ func InstantiateChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, cc
 
 // InstantiateJavaChaincode instantiates the given java chaincode to the given channel
 func InstantiateJavaChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVersion string, ccPolicyStr string, args [][]byte, collConfigs ...*pb.CollectionConfig) (resmgmt.InstantiateCCResponse, error) {
-	ccPolicy, err := cauthdsl.FromString(ccPolicyStr)
+	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return resmgmt.InstantiateCCResponse{}, errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
 	}
@@ -350,7 +350,7 @@ func InstantiateJavaChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath
 
 // InstantiateNodeChaincode instantiates the given node chaincode to the given channel
 func InstantiateNodeChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVersion string, ccPolicyStr string, args [][]byte, collConfigs ...*pb.CollectionConfig) (resmgmt.InstantiateCCResponse, error) {
-	ccPolicy, err := cauthdsl.FromString(ccPolicyStr)
+	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return resmgmt.InstantiateCCResponse{}, errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
 	}
@@ -372,7 +372,7 @@ func InstantiateNodeChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath
 
 // UpgradeChaincode upgrades the given chaincode on the given channel
 func UpgradeChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVersion string, ccPolicyStr string, args [][]byte, collConfigs ...*pb.CollectionConfig) (resmgmt.UpgradeCCResponse, error) {
-	ccPolicy, err := cauthdsl.FromString(ccPolicyStr)
+	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return resmgmt.UpgradeCCResponse{}, errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
 	}
@@ -393,7 +393,7 @@ func UpgradeChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVers
 
 // UpgradeJavaChaincode upgrades the given java chaincode on the given channel
 func UpgradeJavaChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVersion string, ccPolicyStr string, args [][]byte, collConfigs ...*pb.CollectionConfig) (resmgmt.UpgradeCCResponse, error) {
-	ccPolicy, err := cauthdsl.FromString(ccPolicyStr)
+	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return resmgmt.UpgradeCCResponse{}, errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
 	}
@@ -415,7 +415,7 @@ func UpgradeJavaChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, cc
 
 // UpgradeNodeChaincode upgrades the given node chaincode on the given channel
 func UpgradeNodeChaincode(resMgmt *resmgmt.Client, channelID, ccName, ccPath, ccVersion string, ccPolicyStr string, args [][]byte, collConfigs ...*pb.CollectionConfig) (resmgmt.UpgradeCCResponse, error) {
-	ccPolicy, err := cauthdsl.FromString(ccPolicyStr)
+	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return resmgmt.UpgradeCCResponse{}, errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
 	}

--- a/test/integration/e2e/end_to_end.go
+++ b/test/integration/e2e/end_to_end.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
@@ -200,7 +200,7 @@ func createCC(t *testing.T, orgResMgmt *resmgmt.Client) {
 		t.Fatal(err)
 	}
 	// Set up chaincode policy
-	ccPolicy := cauthdsl.SignedByAnyMember([]string{"Org1MSP"})
+	ccPolicy := policydsl.SignedByAnyMember([]string{"Org1MSP"})
 	// Org resource manager will instantiate 'example_cc' on channel
 	resp, err := orgResMgmt.InstantiateCC(
 		channelID,

--- a/test/integration/e2e/orgs/multiple_orgs_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	mspclient "github.com/hyperledger/fabric-sdk-go/pkg/client/msp"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/resource"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 )
 
 const (
@@ -387,7 +387,7 @@ func upgradeCC(t *testing.T, mc *multiorgContext, ccPkg *resource.CCPackage, ccN
 	require.Truef(t, installed, "Expecting chaincode [%s:%s] to be installed on all peers in Org2")
 
 	// New chaincode policy (both orgs have to approve)
-	org1Andorg2Policy, err := cauthdsl.FromString("AND ('Org1MSP.member','Org2MSP.member')")
+	org1Andorg2Policy, err := policydsl.FromString("AND ('Org1MSP.member','Org2MSP.member')")
 	require.Nil(t, err, "error should be nil for getting cc policy with both orgs to approve")
 
 	// Org1 resource manager will instantiate 'example_cc' version 1 on 'orgchannel'

--- a/test/integration/negative/revoked/revoked_test.go
+++ b/test/integration/negative/revoked/revoked_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/resource"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 )
 
 const (
@@ -489,7 +489,7 @@ func createCC(t *testing.T, sdk1 *fabsdk.FabricSDK, name, path, version string, 
 		t.Fatal(err)
 	}
 	// Set up chaincode policy to 'two-of-two msps'
-	ccPolicy, err := cauthdsl.FromString("AND ('Org1MSP.member','Org2MSP.member')")
+	ccPolicy, err := policydsl.FromString("AND ('Org1MSP.member','Org2MSP.member')")
 	require.NoErrorf(t, err, "Error creating cc policy with both orgs to approve")
 	// Org1 resource manager will instantiate 'example_cc' on 'orgchannel'
 	resp, err := org1ResMgmt.InstantiateCC(

--- a/test/integration/pkg/client/channel/channel_client_pvt_test.go
+++ b/test/integration/pkg/client/channel/channel_client_pvt_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
@@ -346,7 +346,7 @@ func TestChannelClientRollsBackPvtDataIfMvccReadConflict(t *testing.T) {
 }
 
 func newCollectionConfig(colName, policy string, reqPeerCount, maxPeerCount int32, blockToLive uint64) (*pb.CollectionConfig, error) {
-	p, err := cauthdsl.FromString(policy)
+	p, err := policydsl.FromString(policy)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/pkg/client/common/selection/fabricselection_test.go
+++ b/test/integration/pkg/client/common/selection/fabricselection_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/factory/defsvc"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/provider/chpvdr"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 	grpcCodes "google.golang.org/grpc/codes"
 )
 
@@ -346,7 +346,7 @@ func expecting(groups ...[]string) [][]string {
 }
 
 func newCollectionConfig(colName, policy string, reqPeerCount, maxPeerCount int32, blockToLive uint64) (*pb.CollectionConfig, error) {
-	p, err := cauthdsl.FromString(policy)
+	p, err := policydsl.FromString(policy)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/pkg/client/resmgmt/resmgmt_queries_pvt_test.go
+++ b/test/integration/pkg/client/resmgmt/resmgmt_queries_pvt_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,7 +84,7 @@ func checkStaticCollectionConfig(t *testing.T, collConf *pb.StaticCollectionConf
 }
 
 func newCollectionConfig(colName, policy string, reqPeerCount, maxPeerCount int32, blockToLive uint64) (*pb.CollectionConfig, error) {
-	p, err := cauthdsl.FromString(policy)
+	p, err := policydsl.FromString(policy)
 	if err != nil {
 		return nil, err
 	}

--- a/test/performance/pkg/client/channel/chclient_test.go
+++ b/test/performance/pkg/client/channel/chclient_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/util/pathvar"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/core/common/ccprovider"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
@@ -205,7 +205,7 @@ func getConfigBlockPayload() []byte {
 }
 
 func getCCDataPayload() []byte {
-	ccPolicy := cauthdsl.SignedByMspMember("Org1MSP")
+	ccPolicy := policydsl.SignedByMspMember("Org1MSP")
 	pp, err := proto.Marshal(ccPolicy)
 	if err != nil {
 		panic(fmt.Sprintf("failed to build mock CC Policy: %s", err))

--- a/third_party/github.com/hyperledger/fabric/common/policydsl/policydsl_builder.go
+++ b/third_party/github.com/hyperledger/fabric/common/policydsl/policydsl_builder.go
@@ -8,7 +8,7 @@ Notice: This file has been modified for Hyperledger Fabric SDK Go usage.
 Please review third_party pinning scripts and patches for more details.
 */
 
-package cauthdsl
+package policydsl
 
 import (
 	"sort"

--- a/third_party/github.com/hyperledger/fabric/common/policydsl/policyparser.go
+++ b/third_party/github.com/hyperledger/fabric/common/policydsl/policyparser.go
@@ -8,7 +8,7 @@ Notice: This file has been modified for Hyperledger Fabric SDK Go usage.
 Please review third_party pinning scripts and patches for more details.
 */
 
-package cauthdsl
+package policydsl
 
 import (
 	"fmt"


### PR DESCRIPTION
This change renames the cauthdsl to policydsl to match with Fabric.

Signed-off-by: Troy Ronda <troy@troyronda.com>