### PR TITLE
[FABG-1005] chaincoded should use distinct separator

### DIFF
--- a/pkg/client/channel/api.go
+++ b/pkg/client/channel/api.go
@@ -50,6 +50,7 @@ type Request struct {
 	// The invoked chaincode (specified by ChaincodeID) may optionally be added to the invocation
 	// chain along with any collections, otherwise it may be omitted.
 	InvocationChain []*fab.ChaincodeCall
+	IsInit          bool
 }
 
 //Response contains response parameters for query and execute an invocation transaction

--- a/pkg/client/channel/invoke/api.go
+++ b/pkg/client/channel/invoke/api.go
@@ -50,6 +50,7 @@ type Request struct {
 	// The invoked chaincode (specified by ChaincodeID) may optionally be added to the invocation
 	// chain along with any collections, otherwise it may be omitted.
 	InvocationChain []*fab.ChaincodeCall
+	IsInit          bool
 }
 
 //Response contains response parameters for query and execute transaction

--- a/pkg/client/channel/invoke/txnhandler.go
+++ b/pkg/client/channel/invoke/txnhandler.go
@@ -281,6 +281,7 @@ func createAndSendTransactionProposal(transactor fab.ProposalSender, chrequest *
 		Fcn:          chrequest.Fcn,
 		Args:         chrequest.Args,
 		TransientMap: chrequest.TransientMap,
+		IsInit:       chrequest.IsInit,
 	}
 
 	txh, err := transactor.CreateTransactionHeader(opts...)

--- a/pkg/common/providers/fab/proposer.go
+++ b/pkg/common/providers/fab/proposer.go
@@ -70,6 +70,7 @@ type ChaincodeInvokeRequest struct {
 	TransientMap map[string][]byte
 	Fcn          string
 	Args         [][]byte
+	IsInit       bool
 }
 
 // TransactionProposal contains a marashalled transaction proposal.

--- a/pkg/common/providers/fab/proposer.go
+++ b/pkg/common/providers/fab/proposer.go
@@ -64,6 +64,7 @@ type TransactionHeader interface {
 }
 
 // ChaincodeInvokeRequest contains the parameters for sending a transaction proposal.
+// nolint: maligned
 type ChaincodeInvokeRequest struct {
 	ChaincodeID  string
 	Lang         pb.ChaincodeSpec_Type

--- a/pkg/fab/txn/proposal.go
+++ b/pkg/fab/txn/proposal.go
@@ -42,7 +42,7 @@ func CreateChaincodeInvokeProposal(txh fab.TransactionHeader, request fab.Chainc
 	// create invocation spec to target a chaincode with arguments
 	ccis := &pb.ChaincodeInvocationSpec{ChaincodeSpec: &pb.ChaincodeSpec{
 		Type: request.Lang, ChaincodeId: &pb.ChaincodeID{Name: request.ChaincodeID},
-		Input: &pb.ChaincodeInput{Args: argsArray}}}
+		Input: &pb.ChaincodeInput{Args: argsArray, IsInit: request.IsInit}}}
 
 	proposal, _, err := protoutil.CreateChaincodeProposalWithTxIDNonceAndTransient(string(txh.TransactionID()), common.HeaderType_ENDORSER_TRANSACTION, txh.ChannelID(), ccis, txh.Nonce(), txh.Creator(), request.TransientMap)
 	if err != nil {

--- a/scripts/_go/src/chaincoded/cmd/chaincoded/chaincoded.go
+++ b/scripts/_go/src/chaincoded/cmd/chaincoded/chaincoded.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	binaryRegExp         = regexp.MustCompile("(.*)_(.*)")
+	binaryRegExp         = regexp.MustCompile("(.*)_fabtest_(.*)")
 	containerCreateRegEx = regexp.MustCompile("/containers/create")
 	containerNameRegEx   = regexp.MustCompile("(.*)-(.*)-(.*)-(.*)")
 	containerStartRegEx  = regexp.MustCompile("/containers/(.+)/start")

--- a/test/fixtures/fabric/v2.2/config/configtx.yaml
+++ b/test/fixtures/fabric/v2.2/config/configtx.yaml
@@ -147,34 +147,41 @@ Organizations:
 #
 ################################################################################
 Capabilities:
-    # Global capabilities apply to both the orderers and the peers and must be
-    # supported by both.  Set the value of the capability to true to require it.
+    # Channel capabilities apply to both the orderers and the peers and must be
+    # supported by both.
+    # Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        # V1.1 for Global is a catchall flag for behavior which has been
-        # determined to be desired for all orderers and peers running v1.0.x,
-        # but the modification of which would cause imcompatibilities.  Users
-        # should leave this flag set to true.
-        V1_1: true
+        # V2_0 capability ensures that orderers and peers behave according
+        # to v2.0 channel capabilities. Orderers and peers from
+        # prior releases would behave in an incompatible way, and are therefore
+        # not able to participate in channels at v2.0 capability.
+        # Prior to enabling V2.0 channel capabilities, ensure that all
+        # orderers and peers on a channel are at v2.0.0 or later.
+        V2_0: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
-    # manipulated without concern for upgrading peers.  Set the value of the
-    # capability to true to require it.
+    # used with prior release peers.
+    # Set the value of the capability to true to require it.
     Orderer: &OrdererCapabilities
-        # V1.1 for Order is a catchall flag for behavior which has been
-        # determined to be desired for all orderers running v1.0.x, but the
-        # modification of which  would cause imcompatibilities.  Users should
-        # leave this flag set to true.
-        V1_1: true
+        # V2_0 orderer capability ensures that orderers behave according
+        # to v2.0 orderer capabilities. Orderers from
+        # prior releases would behave in an incompatible way, and are therefore
+        # not able to participate in channels at v2.0 orderer capability.
+        # Prior to enabling V2.0 orderer capabilities, ensure that all
+        # orderers on channel are at v2.0.0 or later.
+        V2_0: true
 
     # Application capabilities apply only to the peer network, and may be safely
-    # manipulated without concern for upgrading orderers.  Set the value of the
-    # capability to true to require it.
+    # used with prior release orderers.
+    # Set the value of the capability to true to require it.
     Application: &ApplicationCapabilities
-        # V1.1 for Application is a catchall flag for behavior which has been
-        # determined to be desired for all peers running v1.0.x, but the
-        # modification of which would cause incompatibilities.  Users should
-        # leave this flag set to true.
-        V1_2: true
+        # V2_0 application capability ensures that peers behave according
+        # to v2.0 application capabilities. Peers from
+        # prior releases would behave in an incompatible way, and are therefore
+        # not able to participate in channels at v2.0 application capability.
+        # Prior to enabling V2.0 application capabilities, ensure that all
+        # peers on channel are at v2.0.0 or later.
+        V2_0: true
 
 
 ################################################################################
@@ -270,6 +277,20 @@ Application: &ApplicationDefaults
         #
         #User's can override these defaults with their own policy mapping by defining the
         #mapping under ACLs in their channel definition
+
+        #---New Lifecycle System Chaincode (_lifecycle) function to policy mapping for access control--#
+
+        # ACL policy for _lifecycle's "CheckCommitReadiness" function
+        _lifecycle/CheckCommitReadiness: /Channel/Application/Writers
+
+        # ACL policy for _lifecycle's "CommitChaincodeDefinition" function
+        _lifecycle/CommitChaincodeDefinition: /Channel/Application/Writers
+
+        # ACL policy for _lifecycle's "QueryChaincodeDefinition" function
+        _lifecycle/QueryChaincodeDefinition: /Channel/Application/Readers
+
+        # ACL policy for _lifecycle's "QueryChaincodeDefinitions" function
+        _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Readers
 
         #---Lifecycle System Chaincode (lscc) function to policy mapping for access control---#
 

--- a/test/integration/base_test_setup.go
+++ b/test/integration/base_test_setup.go
@@ -95,9 +95,19 @@ func ExampleCCInitArgs() [][]byte {
 	return initArgs
 }
 
+//ExampleCCInitArgsLc returns example cc initialization args
+func ExampleCCInitArgsLc() [][]byte {
+	return initArgs[1:]
+}
+
 //ExampleCCUpgradeArgs returns example cc upgrade args
 func ExampleCCUpgradeArgs() [][]byte {
 	return upgradeArgs
+}
+
+//ExampleCCUpgradeArgsLc returns example cc upgrade args
+func ExampleCCUpgradeArgsLc() [][]byte {
+	return upgradeArgs[1:]
 }
 
 // IsJoinedChannel returns true if the given peer has joined the given channel
@@ -165,6 +175,18 @@ func (setup *BaseSetupImpl) Initialize(sdk *fabsdk.FabricSDK) error {
 // GetDeployPath returns the path to the chaincode fixtures
 func GetDeployPath() string {
 	const ccPath = "test/fixtures/testdata/go"
+	return filepath.Join(metadata.GetProjectPath(), ccPath)
+}
+
+// GetLcDeployPath returns the path to the chaincode fixtures
+func GetLcDeployPath() string {
+	const ccPath = "test/fixtures/testdata/go/src/github.com/example_cc"
+	return filepath.Join(metadata.GetProjectPath(), ccPath)
+}
+
+// GetLcPvtDeployPath returns the path to the chaincode fixtures
+func GetLcPvtDeployPath() string {
+	const ccPath = "test/fixtures/testdata/go/src/github.com/example_pvt_cc"
 	return filepath.Join(metadata.GetProjectPath(), ccPath)
 }
 

--- a/test/integration/e2e/end_to_end.go
+++ b/test/integration/e2e/end_to_end.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	ccID = "example_cc_e2e" + metadata.TestRunID
+	ccID = "example_cc_fabtest_e2e" + metadata.TestRunID
 )
 
 // Run enables testing an end-to-end scenario against the supplied SDK options
@@ -274,7 +274,7 @@ func packageCC(t *testing.T) (string, []byte) {
 	desc := &lcpackager.Descriptor{
 		Path:  integration.GetLcDeployPath(),
 		Type:  pb.ChaincodeSpec_GOLANG,
-		Label: "example_cc_0",
+		Label: "example_cc_fabtest_0",
 	}
 	ccPkg, err := lcpackager.NewCCPackage(desc)
 	if err != nil {

--- a/test/integration/e2e/orgs/multi_orgs_ch_update_signatures_test.go
+++ b/test/integration/e2e/orgs/multi_orgs_ch_update_signatures_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/provider/chpvdr"
 	"github.com/hyperledger/fabric-sdk-go/pkg/util/test"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 )
 
 const (
@@ -74,7 +75,7 @@ type chCfgSignatures struct {
 // DistributedSignaturesTests will create at least 2 clients, each from 2 different orgs and creates two channel where these 2 orgs are members
 // one channel created by using the conventional SDK signatures (exported into a file and loaded to simulate external signature loading)
 // the second one is created by using OpenSSL to sign the channel Config data.
-func DistributedSignaturesTests(t *testing.T, exampleCC string) {
+func DistributedSignaturesTests(t *testing.T) {
 	ordererClCtx := createDSClientCtx(t, ordererOrgName)
 	defer ordererClCtx.sdk.Close()
 
@@ -83,13 +84,14 @@ func DistributedSignaturesTests(t *testing.T, exampleCC string) {
 
 	org2ClCtx := createDSClientCtx(t, org2)
 	defer org2ClCtx.sdk.Close()
-
+	ccID1 := integration.GenerateExampleID(true)
 	// use SDK signing
-	e2eCreateAndQueryChannel(t, ordererClCtx, org1ClCtx, org2ClCtx, dsChannelSDK, exampleCC)
+	e2eCreateAndQueryChannel(t, ordererClCtx, org1ClCtx, org2ClCtx, dsChannelSDK, ccID1)
 
 	if isOpensslAvailable(t) {
+		ccID2 := integration.GenerateExampleID(true)
 		// use OpenSSL signing
-		e2eCreateAndQueryChannel(t, ordererClCtx, org1ClCtx, org2ClCtx, dsChannelExternal, exampleCC)
+		e2eCreateAndQueryChannel(t, ordererClCtx, org1ClCtx, org2ClCtx, dsChannelExternal, ccID2)
 	}
 
 	// modify channel config, must be endorsed by two orgs
@@ -301,19 +303,37 @@ func e2eCreateAndQueryChannel(t *testing.T, ordererClCtx, org1ClCtx, org2ClCtx *
 	require.NoError(t, err)
 
 	ccVersion := "1" // ccVersion= 1 because previous test increased the ccVersion # on the peers.
+	if metadata.Ccmode == "Lscc" {
+		// instantiate example_CC on dschannel
+		instantiateCC(t, org1ClCtx.rsCl, examplecc, ccVersion, channelID)
 
-	// instantiate example_CC on dschannel
-	instantiateCC(t, org1ClCtx.rsCl, exampleCC, ccVersion, channelID)
+		// Ensure the CC is instantiated on all peers in both orgs
+		found := queryInstantiatedCC(t, org1, org1ClCtx.rsCl, channelID, examplecc, ccVersion, org1Peers)
+		require.True(t, found, "Failed to find instantiated chaincode [%s:%s] in at least one peer in Org1 on channel [%s]", examplecc, ccVersion, channelID)
 
-	// Ensure the CC is instantiated on all peers in both orgs
-	found := queryInstantiatedCC(t, org1, org1ClCtx.rsCl, channelID, exampleCC, ccVersion, org1Peers)
-	require.True(t, found, "Failed to find instantiated chaincode [%s:%s] in at least one peer in Org1 on channel [%s]", exampleCC, ccVersion, channelID)
-
-	found = queryInstantiatedCC(t, org2, org2ClCtx.rsCl, channelID, exampleCC, ccVersion, org2Peers)
-	require.True(t, found, "Failed to find instantiated chaincode [%s:%s] in at least one peer in Org2 on channel [%s]", exampleCC, ccVersion, channelID)
-
-	// test regular querying on dschannel from org1 and org2
-	testQueryingOrgs(t, org1ClCtx.sdk, org2ClCtx.sdk, channelID, examplecc)
+		found = queryInstantiatedCC(t, org2, org2ClCtx.rsCl, channelID, examplecc, ccVersion, org2Peers)
+		require.True(t, found, "Failed to find instantiated chaincode [%s:%s] in at least one peer in Org2 on channel [%s]", examplecc, ccVersion, channelID)
+		// test regular querying on dschannel from org1 and org2
+		testQueryingOrgs(t, org1ClCtx.sdk, org2ClCtx.sdk, channelID, examplecc)
+	} else {
+		// TODO: dsChannelExternal needs to be complete
+		if channelID == dsChannelSDK {
+			mc := &multiorgContext{
+				// client contexts
+				ordererClientContext:   ordererClCtx.clCtx,
+				org1AdminClientContext: org1ClCtx.clCtx,
+				org2AdminClientContext: org2ClCtx.clCtx,
+				org1ResMgmt:            org1ClCtx.rsCl,
+				org2ResMgmt:            org2ClCtx.rsCl,
+				ccName:                 examplecc,
+				ccVersion:              ccVersion,
+				channelID:              channelID,
+			}
+			createCCLifecycle(t, mc, examplecc, ccVersion, 1, true, channelID, org1ClCtx.sdk)
+			// test regular querying on dschannel from org1 and org2
+			testQueryingOrgs(t, org1ClCtx.sdk, org2ClCtx.sdk, channelID, examplecc)
+		}
+	}
 }
 
 func generateSignatures(t *testing.T, org1ClCtx, org2ClCtx *dsClientCtx, chConfigPath, chConfigOrg1MSPPath, chConfigOrg2MSPPath, sigDir string, isSDKSigning bool) chCfgSignatures {

--- a/test/integration/e2e/orgs/multiple_orgs_minconfig_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_minconfig_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	bootStrapCC    = "example_cc_btsp"
+	bootStrapCC    = "example_cc_fabtest_btsp"
 	configFilename = "config_e2e_multiorg_bootstrap.yaml"
 )
 

--- a/test/integration/e2e/orgs/multiple_orgs_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_test.go
@@ -63,7 +63,7 @@ var (
 	// Peers
 	orgTestPeer0 fab.Peer
 	orgTestPeer1 fab.Peer
-	exampleCC    = "example_cc_e2e" + metadata.TestRunID
+	exampleCC    = "example_cc_fabtest_e2e" + metadata.TestRunID
 )
 
 // used to create context for different tests in the orgs package

--- a/test/integration/e2e/orgs/multiple_orgs_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_test.go
@@ -17,17 +17,20 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	contextAPI "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
 	packager "github.com/hyperledger/fabric-sdk-go/pkg/fab/ccpackager/gopackager"
+	lcpackager "github.com/hyperledger/fabric-sdk-go/pkg/fab/ccpackager/lifecycle"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	mb "github.com/hyperledger/fabric-protos-go/msp"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/ledger"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
-	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
 
@@ -157,7 +160,7 @@ func TestOrgsEndToEnd(t *testing.T) {
 	TestMultiOrgWithSingleOrgConfig(t, exampleCC)
 
 	//test Distributed signatures with 2 orgs (1 SDK per org, signature test done by SDK and another one done by OpenSSL)
-	DistributedSignaturesTests(t, exampleCC)
+	DistributedSignaturesTests(t)
 }
 
 func createAndJoinChannel(t *testing.T, mc *multiorgContext) {
@@ -202,13 +205,19 @@ func testWithOrg1(t *testing.T, sdk *fabsdk.FabricSDK, mc *multiorgContext) int 
 	org1ChannelClientContext := sdk.ChannelContext(mc.channelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1))
 	org2ChannelClientContext := sdk.ChannelContext(mc.channelID, fabsdk.WithUser(org2User), fabsdk.WithOrg(org2))
 
-	ccPkg, err := packager.NewCCPackage(ccPath, integration.GetDeployPath())
-	if err != nil {
-		t.Fatal(err)
-	}
+	var ccPkg *resource.CCPackage
+	var err error
 
 	// Create chaincode package for example cc
-	createCC(t, mc, ccPkg, mc.ccName, mc.ccVersion)
+	if metadata.Ccmode == "Lscc" {
+		ccPkg, err = packager.NewCCPackage(ccPath, integration.GetDeployPath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		createCC(t, mc, ccPkg, mc.ccName, mc.ccVersion)
+	} else {
+		createCCLifecycle(t, mc, mc.ccName, mc.ccVersion, 1, false, mc.channelID, sdk)
+	}
 
 	chClientOrg1User, chClientOrg2User := createOrgsChannelClients(org1ChannelClientContext, t, org2ChannelClientContext)
 
@@ -237,7 +246,11 @@ func testWithOrg1(t *testing.T, sdk *fabsdk.FabricSDK, mc *multiorgContext) int 
 	checkLedgerInfo(ledgerClient, t, ledgerInfoBefore, transactionID)
 
 	// Start chaincode upgrade process (install and instantiate new version of exampleCC)
-	upgradeCC(t, mc, ccPkg, mc.ccName, "1")
+	if metadata.Ccmode == "Lscc" {
+		upgradeCC(t, mc, ccPkg, mc.ccName, "1")
+	} else {
+		createCCLifecycle(t, mc, mc.ccName, "1", 2, true, mc.channelID, sdk)
+	}
 
 	// Org2 user moves funds on org2 peer (cc policy fails since both Org1 and Org2 peers should participate)
 	testCCPolicy(chClientOrg2User, t, mc.ccName)
@@ -676,6 +689,236 @@ func loadOrgPeers(t *testing.T, ctxProvider contextAPI.ClientProvider) {
 	orgTestPeer1, err = ctx.InfraProvider().CreatePeerFromConfig(&fab.NetworkPeer{PeerConfig: org2Peers[0]})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+}
+
+// createCCLifecycle package cc, install cc, get installed cc package, query installed cc
+// approve cc, query approve cc, check commit readiness, commit cc, query committed cc
+func createCCLifecycle(t *testing.T, mc *multiorgContext, ccName, ccVersion string, sequence int64, upgrade bool, channelID string, sdk *fabsdk.FabricSDK) {
+	// Package cc
+	label, ccPkg := packageCC(t, ccName, ccVersion)
+	packageID := lcpackager.ComputePackageID(label, ccPkg)
+
+	// Install cc
+	installCC(t, label, ccPkg, mc)
+
+	// Get installed cc package
+	getInstalledCCPackage(t, packageID, ccPkg, mc)
+
+	// Query installed cc
+	queryInstalled(t, label, packageID, mc)
+
+	// Approve cc
+	approveCC(t, packageID, ccName, ccVersion, sequence, channelID, mc)
+
+	// Query approve cc
+	queryApprovedCC(t, ccName, sequence, channelID, mc)
+
+	// Check commit readiness
+	checkCCCommitReadiness(t, packageID, ccName, ccVersion, sequence, channelID, mc)
+
+	// Commit cc
+	commitCC(t, ccName, ccVersion, sequence, channelID, mc)
+
+	// Query committed cc
+	queryCommittedCC(t, ccName, channelID, mc)
+
+	// Init cc
+	initCC(t, ccName, upgrade, channelID, sdk)
+}
+
+func packageCC(t *testing.T, ccName, ccVersion string) (string, []byte) {
+	label := ccName + "_" + ccVersion
+	desc := &lcpackager.Descriptor{
+		Path:  integration.GetLcDeployPath(),
+		Type:  pb.ChaincodeSpec_GOLANG,
+		Label: label,
+	}
+	ccPkg, err := lcpackager.NewCCPackage(desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return desc.Label, ccPkg
+}
+
+func installCC(t *testing.T, label string, ccPkg []byte, mc *multiorgContext) {
+	installCCReq := resmgmt.LifecycleInstallCCRequest{
+		Label:   label,
+		Package: ccPkg,
+	}
+
+	packageID := lcpackager.ComputePackageID(installCCReq.Label, installCCReq.Package)
+
+	resp1, err := mc.org1ResMgmt.LifecycleInstallCC(installCCReq, resmgmt.WithRetry(retry.DefaultResMgmtOpts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, packageID, resp1[0].PackageID)
+	resp2, err := mc.org2ResMgmt.LifecycleInstallCC(installCCReq, resmgmt.WithRetry(retry.DefaultResMgmtOpts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, packageID, resp2[0].PackageID)
+}
+
+func getInstalledCCPackage(t *testing.T, packageID string, ccPkg []byte, mc *multiorgContext) {
+
+	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 1)
+	require.NoError(t, err)
+
+	resp1, err := mc.org1ResMgmt.LifecycleGetInstalledCCPackage(packageID, resmgmt.WithTargets([]fab.Peer{org1Peers[0]}...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, ccPkg, resp1)
+}
+
+func queryInstalled(t *testing.T, label string, packageID string, mc *multiorgContext) {
+	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 1)
+	require.NoError(t, err)
+	resp1, err := mc.org1ResMgmt.LifecycleQueryInstalledCC(resmgmt.WithTargets([]fab.Peer{org1Peers[0]}...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageID1 := ""
+	for _, t := range resp1 {
+		if t.PackageID == packageID {
+			packageID1 = t.PackageID
+		}
+
+	}
+	require.Equal(t, packageID, packageID1)
+
+}
+
+func approveCC(t *testing.T, packageID string, ccName, ccVersion string, sequence int64, channelID string, mc *multiorgContext) {
+	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 1)
+	require.NoError(t, err)
+	org2Peers, err := integration.DiscoverLocalPeers(mc.org2AdminClientContext, 1)
+	require.NoError(t, err)
+	ccPolicy := policydsl.SignedByNOutOfGivenRole(2, mb.MSPRole_MEMBER, []string{"Org1MSP", "Org2MSP"})
+	approveCCReq := resmgmt.LifecycleApproveCCRequest{
+		Name:              ccName,
+		Version:           ccVersion,
+		PackageID:         packageID,
+		Sequence:          sequence,
+		EndorsementPlugin: "escc",
+		ValidationPlugin:  "vscc",
+		SignaturePolicy:   ccPolicy,
+		InitRequired:      true,
+	}
+
+	txnID1, err := mc.org1ResMgmt.LifecycleApproveCC(channelID, approveCCReq, resmgmt.WithTargets(org1Peers...), resmgmt.WithOrdererEndpoint("orderer.example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotEmpty(t, txnID1)
+
+	txnID2, err := mc.org2ResMgmt.LifecycleApproveCC(channelID, approveCCReq, resmgmt.WithTargets(org2Peers...), resmgmt.WithOrdererEndpoint("orderer.example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotEmpty(t, txnID2)
+}
+
+func queryApprovedCC(t *testing.T, ccName string, sequence int64, channelID string, mc *multiorgContext) {
+	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 1)
+	require.NoError(t, err)
+	queryApprovedCCReq := resmgmt.LifecycleQueryApprovedCCRequest{
+		Name:     ccName,
+		Sequence: sequence,
+	}
+	resp1, err := mc.org1ResMgmt.LifecycleQueryApprovedCC(channelID, queryApprovedCCReq, resmgmt.WithTargets([]fab.Peer{org1Peers[0]}...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotNil(t, resp1)
+
+}
+
+func checkCCCommitReadiness(t *testing.T, packageID string, ccName, ccVersion string, sequence int64, channelID string, mc *multiorgContext) {
+	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 1)
+	require.NoError(t, err)
+
+	ccPolicy := policydsl.SignedByNOutOfGivenRole(2, mb.MSPRole_MEMBER, []string{"Org1MSP", "Org2MSP"})
+	req := resmgmt.LifecycleCheckCCCommitReadinessRequest{
+		Name:              ccName,
+		Version:           ccVersion,
+		PackageID:         packageID,
+		EndorsementPlugin: "escc",
+		ValidationPlugin:  "vscc",
+		SignaturePolicy:   ccPolicy,
+		Sequence:          sequence,
+	}
+	resp1, err := mc.org1ResMgmt.LifecycleCheckCCCommitReadiness(channelID, req, resmgmt.WithTargets([]fab.Peer{org1Peers[0]}...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotNil(t, resp1)
+
+}
+
+func commitCC(t *testing.T, ccName, ccVersion string, sequence int64, channelID string, mc *multiorgContext) {
+	ccPolicy := policydsl.SignedByNOutOfGivenRole(2, mb.MSPRole_MEMBER, []string{"Org1MSP", "Org2MSP"})
+	req := resmgmt.LifecycleCommitCCRequest{
+		Name:              ccName,
+		Version:           ccVersion,
+		Sequence:          sequence,
+		EndorsementPlugin: "escc",
+		ValidationPlugin:  "vscc",
+		SignaturePolicy:   ccPolicy,
+		InitRequired:      true,
+	}
+	txnID, err := mc.org1ResMgmt.LifecycleCommitCC(channelID, req, resmgmt.WithOrdererEndpoint("orderer.example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotEmpty(t, txnID)
+}
+
+func queryCommittedCC(t *testing.T, ccName string, channelID string, mc *multiorgContext) {
+	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 1)
+	require.NoError(t, err)
+
+	req := resmgmt.LifecycleQueryCommittedCCRequest{
+		Name: ccName,
+	}
+	resp1, err := mc.org1ResMgmt.LifecycleQueryCommittedCC(channelID, req, resmgmt.WithTargets([]fab.Peer{org1Peers[0]}...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ccName1 := ""
+	for _, t := range resp1 {
+		if t.Name == ccName {
+			ccName1 = t.Name
+		}
+	}
+	require.Equal(t, ccName, ccName1)
+
+}
+
+func initCC(t *testing.T, ccName string, upgrade bool, channelID string, sdk *fabsdk.FabricSDK) {
+	//prepare channel client context using client context
+	clientChannelContext := sdk.ChannelContext(channelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1))
+	// Channel client is used to query and execute transactions (Org1 is default org)
+	client, err := channel.New(clientChannelContext)
+	if err != nil {
+		t.Fatalf("Failed to create new channel client: %s", err)
+	}
+
+	var args [][]byte
+	if upgrade {
+		args = integration.ExampleCCUpgradeArgsLc()
+	} else {
+		args = integration.ExampleCCInitArgsLc()
+	}
+
+	// init
+	_, err = client.Execute(channel.Request{ChaincodeID: ccName, Fcn: "init", Args: args, IsInit: true},
+		channel.WithRetry(retry.DefaultChannelOpts))
+	if err != nil {
+		t.Fatalf("Failed to init: %s", err)
 	}
 
 }

--- a/test/integration/pkg/client/channel/channel_client_pvt_test.go
+++ b/test/integration/pkg/client/channel/channel_client_pvt_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 )
 
 // TestPrivateDataPutAndGet tests put and get for private data
@@ -46,10 +47,15 @@ func TestPrivateDataPutAndGet(t *testing.T) {
 	collConfig, err := newCollectionConfig(coll1, "OR('Org1MSP.member','Org2MSP.member')", 0, 2, 1000)
 	require.NoError(t, err)
 
-	err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
-	require.NoError(t, err)
-	err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
-	require.NoError(t, err)
+	if metadata.Ccmode == "Lscc" {
+		err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
+		require.NoError(t, err)
+		err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+		require.NoError(t, err)
+	} else {
+		err := integration.InstantiatePvtExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+		require.NoError(t, err)
+	}
 
 	ctxProvider := sdk.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
 
@@ -160,10 +166,15 @@ func TestPrivateData(t *testing.T) {
 	collConfig, err := newCollectionConfig(coll1, "OR('Org2MSP.member')", 0, 2, 1000)
 	require.NoError(t, err)
 
-	err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
-	require.NoError(t, err)
-	err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
-	require.NoError(t, err)
+	if metadata.Ccmode == "Lscc" {
+		err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
+		require.NoError(t, err)
+		err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+		require.NoError(t, err)
+	} else {
+		err := integration.InstantiatePvtExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+		require.NoError(t, err)
+	}
 
 	ctxProvider := sdk.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
 
@@ -206,143 +217,151 @@ func TestPrivateData(t *testing.T) {
 // none of the peers of a private collection's org being available. The chaincode policy is defined as (Org1MSP OR Org2MSP)
 // and the collection policy is defined as (Org2MSP).
 func TestPrivateDataWithOrgDown(t *testing.T) {
-	sdk := mainSDK
+	// 'ApproveChaincodeDefinitionForMyOrg' failed: error validating chaincode definition: collection-name: collection1 -- collection member 'Org3MSP' is not part of the channel
+	if metadata.Ccmode == "Lscc" {
+		sdk := mainSDK
 
-	orgsContext := setupMultiOrgContext(t, sdk)
+		orgsContext := setupMultiOrgContext(t, sdk)
 
-	// Just join peers in org1 for now
-	err := integration.EnsureChannelCreatedAndPeersJoined(t, sdk, orgChannelID, "orgchannel.tx", orgsContext)
-	require.NoError(t, err)
-
-	coll1 := "collection1"
-	ccID := integration.GenerateExamplePvtID(true)
-	collConfig, err := newCollectionConfig(coll1, "OR('Org3MSP.member')", 0, 2, 1000)
-	require.NoError(t, err)
-
-	err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
-	require.NoError(t, err)
-	err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member','Org3MSP.member')", collConfig)
-	require.NoError(t, err)
-
-	ctxProvider := sdk.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
-
-	chClient, err := channel.New(ctxProvider)
-	require.NoError(t, err)
-
-	t.Run("Specified Invocation Chain", func(t *testing.T) {
-		_, err := chClient.Execute(
-			channel.Request{
-				ChaincodeID: ccID,
-				Fcn:         "putprivate",
-				Args:        [][]byte{[]byte(coll1), []byte("key"), []byte("value")},
-				InvocationChain: []*fab.ChaincodeCall{
-					{ID: ccID, Collections: []string{coll1}},
-				},
-			},
-			channel.WithRetry(retry.TestRetryOpts),
-		)
-		require.Errorf(t, err, "expecting error due to all Org2MSP peers down")
-	})
-
-	t.Run("Automatic Invocation Chain", func(t *testing.T) {
-		response, err := chClient.Execute(
-			channel.Request{
-				ChaincodeID: ccID,
-				Fcn:         "putprivate",
-				Args:        [][]byte{[]byte(coll1), []byte("key"), []byte("value")},
-			},
-			channel.WithRetry(retry.TestRetryOpts),
-		)
+		// Just join peers in org1 for now
+		err := integration.EnsureChannelCreatedAndPeersJoined(t, sdk, orgChannelID, "orgchannel.tx", orgsContext)
 		require.NoError(t, err)
-		t.Logf("Got %d response(s)", len(response.Responses))
-		require.NotEmptyf(t, response.Responses, "expecting at least one response")
-	})
+
+		coll1 := "collection1"
+		ccID := integration.GenerateExamplePvtID(true)
+		collConfig, err := newCollectionConfig(coll1, "OR('Org3MSP.member')", 0, 2, 1000)
+		require.NoError(t, err)
+
+		err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
+		require.NoError(t, err)
+		err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member','Org3MSP.member')", collConfig)
+		require.NoError(t, err)
+
+		ctxProvider := sdk.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
+
+		chClient, err := channel.New(ctxProvider)
+		require.NoError(t, err)
+
+		t.Run("Specified Invocation Chain", func(t *testing.T) {
+			_, err := chClient.Execute(
+				channel.Request{
+					ChaincodeID: ccID,
+					Fcn:         "putprivate",
+					Args:        [][]byte{[]byte(coll1), []byte("key"), []byte("value")},
+					InvocationChain: []*fab.ChaincodeCall{
+						{ID: ccID, Collections: []string{coll1}},
+					},
+				},
+				channel.WithRetry(retry.TestRetryOpts),
+			)
+			require.Errorf(t, err, "expecting error due to all Org2MSP peers down")
+		})
+
+		t.Run("Automatic Invocation Chain", func(t *testing.T) {
+			response, err := chClient.Execute(
+				channel.Request{
+					ChaincodeID: ccID,
+					Fcn:         "putprivate",
+					Args:        [][]byte{[]byte(coll1), []byte("key"), []byte("value")},
+				},
+				channel.WithRetry(retry.TestRetryOpts),
+			)
+			require.NoError(t, err)
+			t.Logf("Got %d response(s)", len(response.Responses))
+			require.NotEmptyf(t, response.Responses, "expecting at least one response")
+		})
+	}
 }
 
 // Data in a private data collection must be left untouched if the client receives an MVCC_READ_CONFLICT error.
 // We test this by submitting two cumulative changes to a private data collection, ensuring that the MVCC_READ_CONFLICT error
 // is reproduced, then asserting that only one of the changes was applied.
 func TestChannelClientRollsBackPvtDataIfMvccReadConflict(t *testing.T) {
-	orgsContext := setupMultiOrgContext(t, mainSDK)
-	require.NoError(t, integration.EnsureChannelCreatedAndPeersJoined(t, mainSDK, orgChannelID, "orgchannel.tx", orgsContext))
-	// private data collection used for test
-	const coll = "collection1"
-	// collection key used for test
-	const key = "collection_key"
-	ccID := integration.GenerateExamplePvtID(true)
-	collConfig, err := newCollectionConfig(coll, "OR('Org1MSP.member','Org2MSP.member','Org3MSP.member')", 0, 2, 1000)
-	require.NoError(t, err)
-	require.NoError(t, integration.InstallExamplePvtChaincode(orgsContext, ccID))
-	require.NoError(t, integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member','Org3MSP.member')", collConfig))
-	ctxProvider := mainSDK.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
-	chClient, err := channel.New(ctxProvider)
-	require.NoError(t, err)
+	// 'ApproveChaincodeDefinitionForMyOrg' failed: error validating chaincode definition: collection-name: collection1 -- collection member 'Org3MSP' is not part of the channel
+	if metadata.Ccmode == "Lscc" {
+		orgsContext := setupMultiOrgContext(t, mainSDK)
+		require.NoError(t, integration.EnsureChannelCreatedAndPeersJoined(t, mainSDK, orgChannelID, "orgchannel.tx", orgsContext))
+		// private data collection used for test
+		const coll = "collection1"
+		// collection key used for test
+		const key = "collection_key"
+		ccID := integration.GenerateExamplePvtID(true)
+		collConfig, err := newCollectionConfig(coll, "OR('Org1MSP.member','Org2MSP.member','Org3MSP.member')", 0, 2, 1000)
+		require.NoError(t, err)
 
-	var errMtx sync.Mutex
-	errs := multi.Errors{}
-	var wg sync.WaitGroup
+		require.NoError(t, integration.InstallExamplePvtChaincode(orgsContext, ccID))
+		require.NoError(t, integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member','Org3MSP.member')", collConfig))
 
-	// test function; invokes a CC function that mutates the private data collection
-	changePvtData := func(amount int) {
-		defer wg.Done()
-		_, err := chClient.Execute(
-			channel.Request{
-				ChaincodeID: ccID,
-				Fcn:         "addToInt",
-				Args:        [][]byte{[]byte(coll), []byte(key), []byte(strconv.Itoa(amount))},
-			},
-		)
-		if err != nil {
-			errMtx.Lock()
-			errs = append(errs, err)
-			errMtx.Unlock()
-			return
-		}
-	}
+		ctxProvider := mainSDK.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
+		chClient, err := channel.New(ctxProvider)
+		require.NoError(t, err)
 
-	// expected value at the end of the test
-	const expected = 10
+		var errMtx sync.Mutex
+		errs := multi.Errors{}
+		var wg sync.WaitGroup
 
-	wg.Add(2)
-	go changePvtData(expected)
-	go changePvtData(expected)
-	wg.Wait()
-
-	// ensure the MVCC_READ_CONFLICT was reproduced
-	require.Truef(t, len(errs) > 0 && strings.Contains(errs[0].Error(), "MVCC_READ_CONFLICT"), "could not reproduce MVCC_READ_CONFLICT")
-
-	// read current value of private data collection
-	//resp, err := chClient.Query(
-	//	channel.Request{
-	//		ChaincodeID: ccID,
-	//		Fcn:         "getprivate",
-	//		Args:        [][]byte{[]byte(coll), []byte(key)},
-	//	},
-	//	channel.WithRetry(retry.TestRetryOpts),
-	//)
-	resp, err := retry.NewInvoker(retry.New(retry.TestRetryOpts)).Invoke(
-		func() (interface{}, error) {
-			b, e := chClient.Query(
+		// test function; invokes a CC function that mutates the private data collection
+		changePvtData := func(amount int) {
+			defer wg.Done()
+			_, err := chClient.Execute(
 				channel.Request{
 					ChaincodeID: ccID,
-					Fcn:         "getprivate",
-					Args:        [][]byte{[]byte(coll), []byte(key)},
+					Fcn:         "addToInt",
+					Args:        [][]byte{[]byte(coll), []byte(key), []byte(strconv.Itoa(amount))},
 				},
-				channel.WithRetry(retry.TestRetryOpts),
 			)
-			if e != nil || strings.TrimSpace(string(b.Payload)) == "" {
-				return nil, status.New(status.TestStatus, status.GenericTransient.ToInt32(), fmt.Sprintf("getprivate data returned error: %v", e), nil)
+			if err != nil {
+				errMtx.Lock()
+				errs = append(errs, err)
+				errMtx.Unlock()
+				return
 			}
-			return b, e
-		},
-	)
-	require.NoErrorf(t, err, "error attempting to read private data")
-	require.NotEmptyf(t, strings.TrimSpace(string(resp.(channel.Response).Payload)), "reading private data returned empty response")
+		}
 
-	actual, err := strconv.Atoi(string(resp.(channel.Response).Payload))
-	require.NoError(t, err)
+		// expected value at the end of the test
+		const expected = 10
 
-	assert.Truef(t, actual == expected, "Private data not rolled back during MVCC_READ_CONFLICT")
+		wg.Add(2)
+		go changePvtData(expected)
+		go changePvtData(expected)
+		wg.Wait()
+
+		// ensure the MVCC_READ_CONFLICT was reproduced
+		require.Truef(t, len(errs) > 0 && strings.Contains(errs[0].Error(), "MVCC_READ_CONFLICT"), "could not reproduce MVCC_READ_CONFLICT")
+
+		// read current value of private data collection
+		//resp, err := chClient.Query(
+		//	channel.Request{
+		//		ChaincodeID: ccID,
+		//		Fcn:         "getprivate",
+		//		Args:        [][]byte{[]byte(coll), []byte(key)},
+		//	},
+		//	channel.WithRetry(retry.TestRetryOpts),
+		//)
+		resp, err := retry.NewInvoker(retry.New(retry.TestRetryOpts)).Invoke(
+			func() (interface{}, error) {
+				b, e := chClient.Query(
+					channel.Request{
+						ChaincodeID: ccID,
+						Fcn:         "getprivate",
+						Args:        [][]byte{[]byte(coll), []byte(key)},
+					},
+					channel.WithRetry(retry.TestRetryOpts),
+				)
+				if e != nil || strings.TrimSpace(string(b.Payload)) == "" {
+					return nil, status.New(status.TestStatus, status.GenericTransient.ToInt32(), fmt.Sprintf("getprivate data returned error: %v", e), nil)
+				}
+				return b, e
+			},
+		)
+		require.NoErrorf(t, err, "error attempting to read private data")
+		require.NotEmptyf(t, strings.TrimSpace(string(resp.(channel.Response).Payload)), "reading private data returned empty response")
+
+		actual, err := strconv.Atoi(string(resp.(channel.Response).Payload))
+		require.NoError(t, err)
+
+		assert.Truef(t, actual == expected, "Private data not rolled back during MVCC_READ_CONFLICT")
+	}
 }
 
 func newCollectionConfig(colName, policy string, reqPeerCount, maxPeerCount int32, blockToLive uint64) (*pb.CollectionConfig, error) {
@@ -394,10 +413,15 @@ func runPvtDataPreReconcilePutAndGet(t *testing.T, sdk *fabsdk.FabricSDK, orgsCo
 	collConfig, err := newCollectionConfig(coll1, policy, 0, 2, 1000)
 	require.NoError(t, err)
 
-	err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
-	require.NoError(t, err)
-	err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, policy, collConfig)
-	require.NoError(t, err)
+	if metadata.Ccmode == "Lscc" {
+		err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
+		require.NoError(t, err)
+		err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, policy, collConfig)
+		require.NoError(t, err)
+	} else {
+		err := integration.InstantiatePvtExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, policy, collConfig)
+		require.NoError(t, err)
+	}
 
 	ctxProvider := sdk.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
 
@@ -542,9 +566,13 @@ func runPvtDataPostReconcileGet(t *testing.T, sdk *fabsdk.FabricSDK, orgsContext
 
 	// org2 peers are the only targets to test post reconciliation as they should have the pvt data after cc upgrade as per the new collection policy (multiOrgsPolicy)
 	org2TargetOpts := channel.WithTargetEndpoints("peer0.org2.example.com", "peer1.org2.example.com")
-
-	err = integration.UpgradeExamplePvtChaincode(orgsContext, orgChannelID, ccID, policy, collConfig)
-	require.NoError(t, err)
+	if metadata.Ccmode == "Lscc" {
+		err = integration.UpgradeExamplePvtChaincode(orgsContext, orgChannelID, ccID, policy, collConfig)
+		require.NoError(t, err)
+	} else {
+		err = integration.UpgradeExamplePvtChaincodeLc(sdk, orgsContext, orgChannelID, ccID, policy, collConfig)
+		require.NoError(t, err)
+	}
 
 	// wait for pvt data reconciliation occurs on peers of org2
 	time.Sleep(2 * time.Second)

--- a/test/integration/pkg/client/channel/channel_client_test.go
+++ b/test/integration/pkg/client/channel/channel_client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 )
 
 func TestChannelClient(t *testing.T) {
@@ -82,8 +83,13 @@ func TestChannelClient(t *testing.T) {
 
 	// transaction
 	nestedCCID := integration.GenerateExampleID(true)
-	err = integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, nestedCCID)
-	require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	if metadata.Ccmode == "Lscc" {
+		err = integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, nestedCCID)
+		require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	} else {
+		err = integration.PrepareExampleCCLc(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, nestedCCID)
+		require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	}
 
 	//perform Transaction
 	testTransaction(t, chClient, chaincodeID, nestedCCID, moveOneTx)
@@ -241,16 +247,27 @@ func TestCCToCC(t *testing.T) {
 	require.NoError(t, err)
 
 	cc1ID := integration.GenerateExampleID(true)
-	err = integration.InstallExampleChaincode(orgsContext, cc1ID)
-	require.NoError(t, err)
-	err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, cc1ID, "OR('Org1MSP.member')")
-	require.NoError(t, err)
+	if metadata.Ccmode == "Lscc" {
+		err = integration.InstallExampleChaincode(orgsContext, cc1ID)
+		require.NoError(t, err)
+		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, cc1ID, "OR('Org1MSP.member')")
+		require.NoError(t, err)
+	} else {
+		err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, cc1ID, "OR('Org1MSP.member')")
+		require.NoError(t, err)
+	}
 
 	cc2ID := integration.GenerateExampleID(true)
-	err = integration.InstallExampleChaincode(orgsContext, cc2ID)
-	require.NoError(t, err)
-	err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, cc2ID, "AND('Org1MSP.member','Org2MSP.member')")
-	require.NoError(t, err)
+	if metadata.Ccmode == "Lscc" {
+		err = integration.InstallExampleChaincode(orgsContext, cc2ID)
+		require.NoError(t, err)
+		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, cc2ID, "AND('Org1MSP.member','Org2MSP.member')")
+		require.NoError(t, err)
+	} else {
+
+		err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, cc2ID, "AND('Org1MSP.member','Org2MSP.member')")
+		require.NoError(t, err)
+	}
 
 	ctxProvider := sdk.ChannelContext(orgChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
 

--- a/test/integration/pkg/client/common/discovery/discoveryclient_test.go
+++ b/test/integration/pkg/client/common/discovery/discoveryclient_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/comm"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -171,10 +172,17 @@ func TestDiscoveryClientEndorsers(t *testing.T) {
 
 	t.Run("Policy: Org1 Only", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member')")
-		require.NoError(t, err)
+
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		} else {
+
+			err = integration.InstantiateExampleChaincodeLc(mainSDK, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, mainSDK,
@@ -187,10 +195,16 @@ func TestDiscoveryClientEndorsers(t *testing.T) {
 
 	t.Run("Policy: Org2 Only", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org2MSP.member')")
-		require.NoError(t, err)
+
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(mainSDK, orgsContext, orgChannelID, ccID, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, mainSDK,
@@ -203,10 +217,16 @@ func TestDiscoveryClientEndorsers(t *testing.T) {
 
 	t.Run("Policy: Org1 or Org2", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')")
-		require.NoError(t, err)
+
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(mainSDK, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		require.NoError(t, err)
 		testEndorsers(
@@ -222,10 +242,15 @@ func TestDiscoveryClientEndorsers(t *testing.T) {
 
 	t.Run("Policy: Org1 and Org2", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "AND('Org1MSP.member','Org2MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "AND('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(mainSDK, orgsContext, orgChannelID, ccID, "AND('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, mainSDK,
@@ -242,16 +267,26 @@ func TestDiscoveryClientEndorsers(t *testing.T) {
 	t.Run("Policy: CC1(Org1 Only) to CC2(Org2 Only)", func(t *testing.T) {
 
 		ccID1 := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID1)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID1, "OR('Org1MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID1)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID1, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(mainSDK, orgsContext, orgChannelID, ccID1, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		}
 
 		ccID2 := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID2)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID2, "OR('Org2MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID2)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID2, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(mainSDK, orgsContext, orgChannelID, ccID2, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, mainSDK,

--- a/test/integration/pkg/client/common/selection/fabricselection_test.go
+++ b/test/integration/pkg/client/common/selection/fabricselection_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/factory/defsvc"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/provider/chpvdr"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 	grpcCodes "google.golang.org/grpc/codes"
 )
@@ -91,10 +92,15 @@ func TestFabricSelection(t *testing.T) {
 
 	t.Run("Policy: Org1 Only", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, selectionService,
@@ -107,10 +113,15 @@ func TestFabricSelection(t *testing.T) {
 
 	t.Run("Policy: Org2 Only", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org2MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, selectionService,
@@ -123,10 +134,15 @@ func TestFabricSelection(t *testing.T) {
 
 	t.Run("Policy: Org1 or Org2", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, selectionService,
@@ -141,10 +157,15 @@ func TestFabricSelection(t *testing.T) {
 
 	t.Run("Policy: Org1 and Org2", func(t *testing.T) {
 		ccID := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "AND('Org1MSP.member','Org2MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "AND('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "AND('Org1MSP.member','Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, selectionService,
@@ -172,16 +193,26 @@ func TestFabricSelection(t *testing.T) {
 	// Chaincode to Chaincode
 	t.Run("Policy: CC1(Org1 Only) to CC2(Org2 Only)", func(t *testing.T) {
 		ccID1 := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID1)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID1, "OR('Org1MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID1)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID1, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID1, "OR('Org1MSP.member')")
+			require.NoError(t, err)
+		}
 
 		ccID2 := integration.GenerateExampleID(true)
-		err = integration.InstallExampleChaincode(orgsContext, ccID2)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID2, "OR('Org2MSP.member')")
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID2)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID2, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiateExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID2, "OR('Org2MSP.member')")
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, selectionService,
@@ -200,10 +231,15 @@ func TestFabricSelection(t *testing.T) {
 		collConfig, err := newCollectionConfig(coll1, "OR('Org1MSP.member')", 0, 2, 1000)
 		require.NoError(t, err)
 
-		err = integration.InstallExampleChaincode(orgsContext, ccID)
-		require.NoError(t, err)
-		err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
-		require.NoError(t, err)
+		if metadata.Ccmode == "Lscc" {
+			err = integration.InstallExampleChaincode(orgsContext, ccID)
+			require.NoError(t, err)
+			err = integration.InstantiateExampleChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+			require.NoError(t, err)
+		} else {
+			err = integration.InstantiatePvtExampleChaincodeLc(sdk, orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+			require.NoError(t, err)
+		}
 
 		testEndorsers(
 			t, selectionService,

--- a/test/integration/pkg/client/ledger/channel_ledger_test.go
+++ b/test/integration/pkg/client/ledger/channel_ledger_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/ledger"
@@ -81,8 +82,14 @@ func TestLedgerQueries(t *testing.T) {
 	//defer client.Close()
 
 	chaincodeID := integration.GenerateExampleID(false)
-	err := integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
-	require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+
+	if metadata.Ccmode == "Lscc" {
+		err := integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
+		require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	} else {
+		err := integration.PrepareExampleCCLc(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
+		require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	}
 
 	//prepare required contexts
 	channelClientCtx := sdk.ChannelContext(channelID, fabsdk.WithUser("Admin"), fabsdk.WithOrg(orgName))
@@ -138,7 +145,9 @@ func TestLedgerQueries(t *testing.T) {
 
 	require.Nil(t, err, "resmgmt new return error")
 
-	testInstantiatedChaincodes(t, chaincodeID, channelID, resmgmtClient, targets)
+	if metadata.Ccmode == "Lscc" {
+		testInstantiatedChaincodes(t, chaincodeID, channelID, resmgmtClient, targets)
+	}
 
 	testQueryConfigBlock(t, ledgerClient, targets)
 }

--- a/test/integration/pkg/client/resmgmt/resmgmt_queries_pvt_test.go
+++ b/test/integration/pkg/client/resmgmt/resmgmt_queries_pvt_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/stretchr/testify/require"
 )
@@ -27,41 +28,44 @@ const (
 )
 
 func TestQueryCollectionsConfig(t *testing.T) {
-	sdk := mainSDK
+	//TODO: QueryCollectionsConfig for lifycycle
+	if metadata.Ccmode == "Lscc" {
+		sdk := mainSDK
 
-	orgsContext := setupMultiOrgContext(t, sdk)
-	err := integration.EnsureChannelCreatedAndPeersJoined(t, sdk, orgChannelID, "orgchannel.tx", orgsContext)
-	require.NoError(t, err)
+		orgsContext := setupMultiOrgContext(t, sdk)
+		err := integration.EnsureChannelCreatedAndPeersJoined(t, sdk, orgChannelID, "orgchannel.tx", orgsContext)
+		require.NoError(t, err)
 
-	ccID := integration.GenerateExamplePvtID(true)
-	collConfig, err := newCollectionConfig(collCfgName, collCfgPolicy, collCfgRequiredPeerCount, collCfgMaximumPeerCount, collCfgBlockToLive)
-	require.NoError(t, err)
+		ccID := integration.GenerateExamplePvtID(true)
+		collConfig, err := newCollectionConfig(collCfgName, collCfgPolicy, collCfgRequiredPeerCount, collCfgMaximumPeerCount, collCfgBlockToLive)
+		require.NoError(t, err)
 
-	err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
-	require.NoError(t, err)
-	err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
-	require.NoError(t, err)
+		err = integration.InstallExamplePvtChaincode(orgsContext, ccID)
+		require.NoError(t, err)
+		err = integration.InstantiateExamplePvtChaincode(orgsContext, orgChannelID, ccID, "OR('Org1MSP.member','Org2MSP.member')", collConfig)
+		require.NoError(t, err)
 
-	org1AdminClientContext := sdk.Context(fabsdk.WithUser(org1AdminUser), fabsdk.WithOrg(org1Name))
-	client, err := resmgmt.New(org1AdminClientContext)
-	if err != nil {
-		t.Fatalf("Failed to create new resource management client: %s", err)
-	}
+		org1AdminClientContext := sdk.Context(fabsdk.WithUser(org1AdminUser), fabsdk.WithOrg(org1Name))
+		client, err := resmgmt.New(org1AdminClientContext)
+		if err != nil {
+			t.Fatalf("Failed to create new resource management client: %s", err)
+		}
 
-	resp, err := client.QueryCollectionsConfig(orgChannelID, ccID)
-	if err != nil {
-		t.Fatalf("QueryCollectionsConfig return error: %s", err)
-	}
-	if len(resp.Config) != 1 {
-		t.Fatalf("The number of collection config is incorrect, expected 1, got %d", len(resp.Config))
-	}
+		resp, err := client.QueryCollectionsConfig(orgChannelID, ccID)
+		if err != nil {
+			t.Fatalf("QueryCollectionsConfig return error: %s", err)
+		}
+		if len(resp.Config) != 1 {
+			t.Fatalf("The number of collection config is incorrect, expected 1, got %d", len(resp.Config))
+		}
 
-	conf := resp.Config[0]
-	switch cconf := conf.Payload.(type) {
-	case *pb.CollectionConfig_StaticCollectionConfig:
-		checkStaticCollectionConfig(t, cconf.StaticCollectionConfig)
-	default:
-		t.Fatalf("The CollectionConfig.Payload's type is incorrect, expected `CollectionConfig_StaticCollectionConfig`, got %+v", reflect.TypeOf(conf.Payload))
+		conf := resp.Config[0]
+		switch cconf := conf.Payload.(type) {
+		case *pb.CollectionConfig_StaticCollectionConfig:
+			checkStaticCollectionConfig(t, cconf.StaticCollectionConfig)
+		default:
+			t.Fatalf("The CollectionConfig.Payload's type is incorrect, expected `CollectionConfig_StaticCollectionConfig`, got %+v", reflect.TypeOf(conf.Payload))
+		}
 	}
 }
 

--- a/test/integration/pkg/client/resmgmt/resmgmt_queries_test.go
+++ b/test/integration/pkg/client/resmgmt/resmgmt_queries_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 )
 
 func TestResMgmtClientQueries(t *testing.T) {
@@ -43,55 +44,72 @@ func TestResMgmtClientQueries(t *testing.T) {
 
 	// TODO java and node integration tests need to be fixed.
 	/*
-	// test java chaincode installed and instantiated
-	javaCCID := integration.GenerateExampleJavaID(false)
+		// test java chaincode installed and instantiated
+		javaCCID := integration.GenerateExampleJavaID(false)
 
-	testInstalledChaincodes(t, javaCCID, target, client)
+		testInstalledChaincodes(t, javaCCID, target, client)
 
-	testInstantiatedChaincodes(t, orgChannelID, javaCCID, target, client)
+		testInstantiatedChaincodes(t, orgChannelID, javaCCID, target, client)
 
-	// test node chaincode installed and instantiated
-	nodeCCID := integration.GenerateExampleNodeID(false)
+		// test node chaincode installed and instantiated
+		nodeCCID := integration.GenerateExampleNodeID(false)
 
-	testInstalledChaincodes(t, nodeCCID, target, client)
+		testInstalledChaincodes(t, nodeCCID, target, client)
 
-	testInstantiatedChaincodes(t, orgChannelID, nodeCCID, target, client)
+		testInstantiatedChaincodes(t, orgChannelID, nodeCCID, target, client)
 
 	*/
 }
 
 func testInstantiatedChaincodes(t *testing.T, channelID string, ccID string, target string, client *resmgmt.Client) {
-
-	chaincodeQueryResponse, err := client.QueryInstantiatedChaincodes(channelID, resmgmt.WithTargetEndpoints(target), resmgmt.WithRetry(retry.DefaultResMgmtOpts))
-	if err != nil {
-		t.Fatalf("QueryInstantiatedChaincodes return error: %s", err)
-	}
-
-	found := false
-	for _, chaincode := range chaincodeQueryResponse.Chaincodes {
-		t.Logf("**InstantiatedCC: %s", chaincode)
-		if chaincode.Name == ccID {
-			found = true
+	if metadata.Ccmode == "Lscc" {
+		chaincodeQueryResponse, err := client.QueryInstantiatedChaincodes(channelID, resmgmt.WithTargetEndpoints(target), resmgmt.WithRetry(retry.DefaultResMgmtOpts))
+		if err != nil {
+			t.Fatalf("QueryInstantiatedChaincodes return error: %s", err)
 		}
-	}
 
-	if !found {
-		t.Fatalf("QueryInstantiatedChaincodes failed to find instantiated %s chaincode", ccID)
+		found := false
+		for _, chaincode := range chaincodeQueryResponse.Chaincodes {
+			t.Logf("**InstantiatedCC: %s", chaincode)
+			if chaincode.Name == ccID {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Fatalf("QueryInstantiatedChaincodes failed to find instantiated %s chaincode", ccID)
+		}
 	}
 }
 
 func testInstalledChaincodes(t *testing.T, ccID string, target string, client *resmgmt.Client) {
-
-	chaincodeQueryResponse, err := client.QueryInstalledChaincodes(resmgmt.WithTargetEndpoints(target), resmgmt.WithRetry(retry.DefaultResMgmtOpts))
-	if err != nil {
-		t.Fatalf("QueryInstalledChaincodes return error: %s", err)
-	}
-
 	found := false
-	for _, chaincode := range chaincodeQueryResponse.Chaincodes {
-		t.Logf("**InstalledCC: %s", chaincode)
-		if chaincode.Name == ccID {
-			found = true
+	if metadata.Ccmode == "Lscc" {
+		chaincodeQueryResponse, err := client.QueryInstalledChaincodes(resmgmt.WithTargetEndpoints(target), resmgmt.WithRetry(retry.DefaultResMgmtOpts))
+		if err != nil {
+			t.Fatalf("QueryInstalledChaincodes return error: %s", err)
+		}
+
+		for _, chaincode := range chaincodeQueryResponse.Chaincodes {
+			t.Logf("**InstalledCC: %s", chaincode)
+			if chaincode.Name == ccID {
+				found = true
+			}
+		}
+	} else {
+		chaincodeQueryResponse, err := client.LifecycleQueryInstalledCC(resmgmt.WithTargetEndpoints(target), resmgmt.WithRetry(retry.DefaultResMgmtOpts))
+		if err != nil {
+			t.Fatalf("QueryInstalledChaincodes return error: %s", err)
+		}
+
+		for _, re := range chaincodeQueryResponse {
+			for _, cc := range re.References {
+				for _, c := range cc {
+					if c.Name == ccID {
+						found = true
+					}
+				}
+			}
 		}
 	}
 

--- a/test/integration/pkg/fab/install_chaincode_test.go
+++ b/test/integration/pkg/fab/install_chaincode_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/context"
@@ -20,8 +22,6 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/resource"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
-	"github.com/hyperledger/fabric-protos-go/common"
-	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -115,7 +115,7 @@ func testChaincodeInstallUsingChaincodePackage(t *testing.T, sdk *fabsdk.FabricS
 	peers, err := getProposalProcessors(sdk, "Admin", testSetup.OrgID, testSetup.Targets)
 	require.Nil(t, err, "creating peers failed")
 
-	err = installCC(t, reqCtx, "install", "github.com/example_cc_pkg", chainCodeVersion, ccPkg, peers)
+	err = installCC(t, reqCtx, "install", "github.com/example_cc", chainCodeVersion, ccPkg, peers)
 
 	if err != nil {
 		t.Fatalf("installCC return error: %s", err)

--- a/test/integration/pkg/fab/resource_queries_test.go
+++ b/test/integration/pkg/fab/resource_queries_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/resource"
@@ -37,7 +38,11 @@ func TestChannelQueries(t *testing.T) {
 
 	testQueryChannels(t, reqCtx, peers[0])
 
-	testInstalledChaincodes(t, reqCtx, chaincodeID, peers[0])
+	if metadata.Ccmode == "Lscc" {
+		testInstalledChaincodes(t, reqCtx, chaincodeID, peers[0])
+	} else {
+		testInstalledChaincodesLc(t, reqCtx, peers[0])
+	}
 
 }
 
@@ -77,4 +82,19 @@ func testInstalledChaincodes(t *testing.T, reqCtx reqContext.Context, ccID strin
 	if !found {
 		t.Fatalf("QueryInstalledChaincodes failed to find installed %s chaincode", ccID)
 	}
+}
+
+func testInstalledChaincodesLc(t *testing.T, reqCtx reqContext.Context, target fab.ProposalProcessor) {
+	lc := resource.NewLifecycle()
+	// Our target will be primary peer on this channel
+	t.Logf("****QueryInstalledChaincodes for %s", target)
+
+	resp, err := lc.QueryInstalled(reqCtx, target, resource.WithRetry(retry.DefaultResMgmtOpts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, re := range resp.InstalledChaincodes {
+		t.Logf("**InstalledCC: %s", re.PackageID)
+	}
+
 }

--- a/test/integration/pkg/fabsdk/provider/custom_cryptosuite_test.go
+++ b/test/integration/pkg/fabsdk/provider/custom_cryptosuite_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/factory/defcore"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,9 +31,15 @@ func customCryptoSuiteInit(t *testing.T) (*integration.BaseSetupImpl, string) {
 	sdk := mainSDK
 	testSetup := mainTestSetup
 
-	chaincodeID := integration.GenerateExampleID(false)
-	err := integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
-	require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	chaincodeID := integration.GenerateExampleID(true)
+
+	if metadata.Ccmode == "Lscc" {
+		err := integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
+		require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	} else {
+		err := integration.PrepareExampleCCLc(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
+		require.Nil(t, err, "InstallAndInstantiateExampleCC return error")
+	}
 
 	return testSetup, chaincodeID
 }

--- a/test/integration/pkg/fabsdk/provider/sdk_provider_test.go
+++ b/test/integration/pkg/fabsdk/provider/sdk_provider_test.go
@@ -23,69 +23,74 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/factory/defsvc"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk/provider/chpvdr"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDynamicSelection(t *testing.T) {
+	//TODO: DynamicSelection for lifecycle
+	if metadata.Ccmode == "Lscc" {
+		// Using shared SDK instance to increase test speed.
+		testSetup := mainTestSetup
+		aKey := integration.GetKeyName(t)
+		bKey := integration.GetKeyName(t)
+		moveTxArg := integration.ExampleCCTxArgs(aKey, bKey, "1")
+		queryArg := integration.ExampleCCQueryArgs(bKey)
 
-	// Using shared SDK instance to increase test speed.
-	testSetup := mainTestSetup
-	aKey := integration.GetKeyName(t)
-	bKey := integration.GetKeyName(t)
-	moveTxArg := integration.ExampleCCTxArgs(aKey, bKey, "1")
-	queryArg := integration.ExampleCCQueryArgs(bKey)
+		// Create SDK setup for channel client with dynamic selection
+		sdk, err := fabsdk.New(integration.ConfigBackend,
+			fabsdk.WithServicePkg(&DynamicSelectionProviderFactory{}))
 
-	// Create SDK setup for channel client with dynamic selection
-	sdk, err := fabsdk.New(integration.ConfigBackend,
-		fabsdk.WithServicePkg(&DynamicSelectionProviderFactory{}))
+		if err != nil {
+			t.Fatalf("Failed to create new SDK: %s", err)
+		}
+		defer sdk.Close()
 
-	if err != nil {
-		t.Fatalf("Failed to create new SDK: %s", err)
-	}
-	defer sdk.Close()
+		if err = testSetup.Initialize(sdk); err != nil {
+			t.Fatal(err)
+		}
 
-	if err = testSetup.Initialize(sdk); err != nil {
-		t.Fatal(err)
-	}
+		chaincodeID := integration.GenerateExampleID(true)
+		fmt.Printf("TestDynamicSelection cc = %v\n", chaincodeID)
 
-	chaincodeID := integration.GenerateExampleID(false)
-	err = integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
-	require.NoError(t, err, "InstallAndInstantiateExampleCC returned error")
+		err = integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), testSetup.OrgID, chaincodeID)
+		require.NoError(t, err, "InstallAndInstantiateExampleCC returned error")
 
-	//prepare contexts
-	org1ChannelClientContext := sdk.ChannelContext(testSetup.ChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
+		//prepare contexts
+		org1ChannelClientContext := sdk.ChannelContext(testSetup.ChannelID, fabsdk.WithUser(org1User), fabsdk.WithOrg(org1Name))
 
-	//Reset example cc keys
-	integration.ResetKeys(t, org1ChannelClientContext, chaincodeID, "200", aKey, bKey)
+		//Reset example cc keys
+		integration.ResetKeys(t, org1ChannelClientContext, chaincodeID, "200", aKey, bKey)
 
-	chClient, err := channel.New(org1ChannelClientContext)
-	require.NoError(t, err, "Failed to create new channel client")
+		chClient, err := channel.New(org1ChannelClientContext)
+		require.NoError(t, err, "Failed to create new channel client")
 
-	//response, err := chClient.Query(channel.Request{ChaincodeID: chaincodeID, Fcn: "invoke", Args: queryArg},
-	//	channel.WithRetry(retry.TestRetryOpts))
-	response, err := retry.NewInvoker(retry.New(retry.TestRetryOpts)).Invoke(
-		func() (interface{}, error) {
-			b, e := chClient.Query(channel.Request{ChaincodeID: chaincodeID, Fcn: "invoke", Args: queryArg},
-				channel.WithRetry(retry.TestRetryOpts))
-			if e != nil {
-				// return a retryable code if key/value query is nil (ie not propagated to all peers yet)
-				if strings.Contains(e.Error(), "Nil amount for") {
-					return nil, status.New(status.TestStatus, status.GenericTransient.ToInt32(), fmt.Sprintf("QueryBlock returned error: %v", e), nil)
+		//response, err := chClient.Query(channel.Request{ChaincodeID: chaincodeID, Fcn: "invoke", Args: queryArg},
+		//	channel.WithRetry(retry.TestRetryOpts))
+		response, err := retry.NewInvoker(retry.New(retry.TestRetryOpts)).Invoke(
+			func() (interface{}, error) {
+				b, e := chClient.Query(channel.Request{ChaincodeID: chaincodeID, Fcn: "invoke", Args: queryArg},
+					channel.WithRetry(retry.TestRetryOpts))
+				if e != nil {
+					// return a retryable code if key/value query is nil (ie not propagated to all peers yet)
+					if strings.Contains(e.Error(), "Nil amount for") {
+						return nil, status.New(status.TestStatus, status.GenericTransient.ToInt32(), fmt.Sprintf("QueryBlock returned error: %v", e), nil)
+					}
 				}
-			}
-			return b, e
-		},
-	)
-	require.NoError(t, err, "Failed to query funds, ccID: %s, queryArgs: [%+v]", chaincodeID, queryArg)
-	value := response.(channel.Response).Payload
+				return b, e
+			},
+		)
+		require.NoError(t, err, "Failed to query funds, ccID: %s, queryArgs: [%+v]", chaincodeID, queryArg)
+		value := response.(channel.Response).Payload
 
-	// Move funds
-	_, err = chClient.Execute(channel.Request{ChaincodeID: chaincodeID, Fcn: "invoke", Args: moveTxArg},
-		channel.WithRetry(retry.DefaultChannelOpts))
-	require.NoError(t, err, "Failed to move funds, ccID: %s, queryArgs:[%+v]", chaincodeID, moveTxArg)
+		// Move funds
+		_, err = chClient.Execute(channel.Request{ChaincodeID: chaincodeID, Fcn: "invoke", Args: moveTxArg},
+			channel.WithRetry(retry.DefaultChannelOpts))
+		require.NoError(t, err, "Failed to move funds, ccID: %s, queryArgs:[%+v]", chaincodeID, moveTxArg)
 
-	valueInt, _ := strconv.Atoi(string(value))
-	verifyValue(t, chClient, queryArg, valueInt+1, chaincodeID)
+		valueInt, _ := strconv.Atoi(string(value))
+		verifyValue(t, chClient, queryArg, valueInt+1, chaincodeID)
+	}
 }
 
 func verifyValue(t *testing.T, chClient *channel.Client, queryArg [][]byte, expectedValue int, ccID string) {

--- a/test/integration/pkg/gateway/gateway.go
+++ b/test/integration/pkg/gateway/gateway.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	ccID = "example_cc_e2e" + metadata.TestRunID
+	ccID = "example_cc_fabtest_e2e" + metadata.TestRunID
 )
 
 // RunWithConfig the basic gateway integration test

--- a/test/integration/prepare.go
+++ b/test/integration/prepare.go
@@ -59,7 +59,7 @@ func GenerateExamplePvtID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_%s%s", examplePvtCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_%s%s", examplePvtCCName, metadata.TestRunID, suffix)
 }
 
 // GenerateExampleID supplies a chaincode name for example_cc
@@ -69,7 +69,7 @@ func GenerateExampleID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_0%s%s", exampleCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_0%s%s", exampleCCName, metadata.TestRunID, suffix)
 }
 
 // GenerateExampleJavaID supplies a java chaincode name for example_cc
@@ -79,7 +79,7 @@ func GenerateExampleJavaID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_0%s%s", exampleJavaCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_0%s%s", exampleJavaCCName, metadata.TestRunID, suffix)
 }
 
 // GenerateExampleNodeID supplies a node chaincode name for example_cc
@@ -89,7 +89,7 @@ func GenerateExampleNodeID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_0%s%s", exampleNodeCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_0%s%s", exampleNodeCCName, metadata.TestRunID, suffix)
 }
 
 // PrepareExampleCC install and instantiate using resource management client

--- a/test/integration/util/runner/runner.go
+++ b/test/integration/util/runner/runner.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/test/integration"
+	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 )
 
 const (
@@ -115,10 +116,17 @@ func (r *Runner) Initialize() {
 	}
 
 	if r.installExampleCC {
-		r.exampleChaincodeID = integration.GenerateExampleID(false)
-		if err := integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), r.testSetup.OrgID, r.exampleChaincodeID); err != nil {
-			panic(fmt.Sprintf("PrepareExampleCC return error: %s", err))
+		r.exampleChaincodeID = integration.GenerateExampleID(true)
+		if metadata.Ccmode == "Lscc" {
+			if err := integration.PrepareExampleCC(sdk, fabsdk.WithUser("Admin"), r.testSetup.OrgID, r.exampleChaincodeID); err != nil {
+				panic(fmt.Sprintf("PrepareExampleCC return error: %s", err))
+			}
+		} else {
+			if err := integration.PrepareExampleCCLc(sdk, fabsdk.WithUser("Admin"), r.testSetup.OrgID, r.exampleChaincodeID); err != nil {
+				panic(fmt.Sprintf("PrepareExampleCCLc return error: %s", err))
+			}
 		}
+
 	}
 }
 

--- a/test/metadata/metadata.go
+++ b/test/metadata/metadata.go
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 package metadata
 
 // ChannelConfigPath is the relative path to the generated channel artifacts directory
-var ChannelConfigPath = "test/fixtures/fabric/v1.4/channel"
+var ChannelConfigPath = "test/fixtures/fabric/v2.2/channel"
 
 // CryptoConfigPath is the relative path to the generated crypto config directory
 var CryptoConfigPath = "test/fixtures/fabric/v1/crypto-config"
@@ -24,3 +24,6 @@ var ProjectPath = ""
 
 // TestRunID is an identifier for the current run of tests
 var TestRunID = ""
+
+// Ccmode is an identifier for the cc mode
+var Ccmode = "Lifecycle"

--- a/test/scripts/integration.sh
+++ b/test/scripts/integration.sh
@@ -107,5 +107,5 @@ GO_LDFLAGS="${GO_LDFLAGS} -X ${PROJECT_MODULE}/test/metadata.ChannelConfigPath=t
 GO_LDFLAGS="${GO_LDFLAGS} -X ${PROJECT_MODULE}/test/metadata.CryptoConfigPath=test/fixtures/fabric/${FABRIC_CRYPTOCONFIG_VERSION}/crypto-config"
 GO_LDFLAGS="${GO_LDFLAGS} -X ${PROJECT_MODULE}/fabric-sdk-go/test/metadata.TestRunID=${FABRIC_SDKGO_TESTRUN_ID}"
 
-${GO_CMD} test ${RACEFLAG} -tags "${GO_TAGS}" ${GO_TESTFLAGS} -ldflags="${GO_LDFLAGS}" ${PKGS[@]} -p 1 -timeout=40m configFile=${CONFIG_FILE} testLocal=${TEST_LOCAL}
+${GO_CMD} test ${RACEFLAG} -tags "${GO_TAGS}" ${GO_TESTFLAGS} -ldflags="${GO_LDFLAGS}" ${PKGS[@]} -p 1 -timeout=120m configFile=${CONFIG_FILE} testLocal=${TEST_LOCAL}
 cd ${PWD_ORIG}


### PR DESCRIPTION
Chaincoded removes the last segment of the chaincode ID when detecting the binary name. The last segment separator is changed to the more distinct _fabtest_.

Signed-off-by: Troy Ronda <troy@troyronda.com>