### PR TITLE
[FABG-1005] chaincoded should use distinct separator

### DIFF
--- a/scripts/_go/src/chaincoded/cmd/chaincoded/chaincoded.go
+++ b/scripts/_go/src/chaincoded/cmd/chaincoded/chaincoded.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	binaryRegExp         = regexp.MustCompile("(.*)_(.*)")
+	binaryRegExp         = regexp.MustCompile("(.*)_fabtest_(.*)")
 	containerCreateRegEx = regexp.MustCompile("/containers/create")
 	containerNameRegEx   = regexp.MustCompile("(.*)-(.*)-(.*)-(.*)")
 	containerStartRegEx  = regexp.MustCompile("/containers/(.+)/start")

--- a/test/integration/e2e/end_to_end.go
+++ b/test/integration/e2e/end_to_end.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	ccID = "example_cc_e2e" + metadata.TestRunID
+	ccID = "example_cc_fabtest_e2e" + metadata.TestRunID
 )
 
 // Run enables testing an end-to-end scenario against the supplied SDK options

--- a/test/integration/e2e/orgs/multiple_orgs_minconfig_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_minconfig_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	bootStrapCC    = "example_cc_btsp"
+	bootStrapCC    = "example_cc_fabtest_btsp"
 	configFilename = "config_e2e_multiorg_bootstrap.yaml"
 )
 

--- a/test/integration/e2e/orgs/multiple_orgs_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_test.go
@@ -60,7 +60,7 @@ var (
 	// Peers
 	orgTestPeer0 fab.Peer
 	orgTestPeer1 fab.Peer
-	exampleCC    = "example_cc_e2e" + metadata.TestRunID
+	exampleCC    = "example_cc_fabtest_e2e" + metadata.TestRunID
 )
 
 // used to create context for different tests in the orgs package

--- a/test/integration/pkg/gateway/gateway.go
+++ b/test/integration/pkg/gateway/gateway.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	ccID = "example_cc_e2e" + metadata.TestRunID
+	ccID = "example_cc_fabtest_e2e" + metadata.TestRunID
 )
 
 // RunWithConfig the basic gateway integration test

--- a/test/integration/prepare.go
+++ b/test/integration/prepare.go
@@ -57,7 +57,7 @@ func GenerateExamplePvtID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_%s%s", examplePvtCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_%s%s", examplePvtCCName, metadata.TestRunID, suffix)
 }
 
 // GenerateExampleID supplies a chaincode name for example_cc
@@ -67,7 +67,7 @@ func GenerateExampleID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_0%s%s", exampleCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_0%s%s", exampleCCName, metadata.TestRunID, suffix)
 }
 
 // GenerateExampleJavaID supplies a java chaincode name for example_cc
@@ -77,7 +77,7 @@ func GenerateExampleJavaID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_0%s%s", exampleJavaCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_0%s%s", exampleJavaCCName, metadata.TestRunID, suffix)
 }
 
 // GenerateExampleNodeID supplies a node chaincode name for example_cc
@@ -87,7 +87,7 @@ func GenerateExampleNodeID(randomize bool) string {
 		suffix = GenerateRandomID()
 	}
 
-	return fmt.Sprintf("%s_0%s%s", exampleNodeCCName, metadata.TestRunID, suffix)
+	return fmt.Sprintf("%s_fabtest_0%s%s", exampleNodeCCName, metadata.TestRunID, suffix)
 }
 
 // PrepareExampleCC install and instantiate using resource management client


### PR DESCRIPTION
Chaincoded removes the last segment of the chaincode ID when detecting the binary name.
The last segment separator is changed to the more distinct `_fabtest_`.

Signed-off-by: Troy Ronda <troy@troyronda.com>