### PR TITLE
refactor argument type of method RegisterTxStatusEvent from interface EventService: string -> fab.TransactionID.

### DIFF
--- a/pkg/client/channel/invoke/txnhandler.go
+++ b/pkg/client/channel/invoke/txnhandler.go
@@ -168,7 +168,7 @@ func (c *CommitTxHandler) Handle(requestContext *RequestContext, clientContext *
 	txnID := requestContext.Response.TransactionID
 
 	//Register Tx event
-	reg, statusNotifier, err := clientContext.EventService.RegisterTxStatusEvent(string(txnID)) // TODO: Change func to use TransactionID instead of string
+	reg, statusNotifier, err := clientContext.EventService.RegisterTxStatusEvent(txnID)
 	if err != nil {
 		requestContext.Error = errors.Wrap(err, "error registering for TxStatus event")
 		return

--- a/pkg/client/event/event.go
+++ b/pkg/client/event/event.go
@@ -113,7 +113,7 @@ func (c *Client) RegisterChaincodeEvent(ccID, eventFilter string) (fab.Registrat
 //
 //  Returns:
 //  the registration and a channel that is used to receive events. The channel is closed when Unregister is called.
-func (c *Client) RegisterTxStatusEvent(txID string) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
+func (c *Client) RegisterTxStatusEvent(txID fab.TransactionID) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
 	return c.eventService.RegisterTxStatusEvent(txID)
 }
 

--- a/pkg/client/event/event_test.go
+++ b/pkg/client/event/event_test.go
@@ -117,9 +117,9 @@ func TestFilteredBlockEvents(t *testing.T) {
 	}
 	defer client.Unregister(registration)
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	eventProducer.Ledger().NewFilteredBlock(
@@ -163,8 +163,8 @@ func TestTxStatusEvents(t *testing.T) {
 
 	client.eventService = eventService
 
-	txID1 := "1234"
-	txID2 := "5678"
+	txID1 := fab.TransactionID("1234")
+	txID2 := fab.TransactionID("5678")
 
 	if _, _, err1 := client.RegisterTxStatusEvent(""); err1 == nil {
 		t.Fatal("expecting error registering for TxStatus event without a TX ID but got none")
@@ -185,7 +185,7 @@ func TestTxStatusEvents(t *testing.T) {
 
 }
 
-func validateTxStatusEvents(t *testing.T, eventProducer *servicemocks.MockProducer, eventch1 <-chan *fab.TxStatusEvent, eventch2 <-chan *fab.TxStatusEvent, chanID string, txID1 string, txID2 string) {
+func validateTxStatusEvents(t *testing.T, eventProducer *servicemocks.MockProducer, eventch1 <-chan *fab.TxStatusEvent, eventch2 <-chan *fab.TxStatusEvent, chanID string, txID1, txID2 fab.TransactionID) {
 	txCode1 := pb.TxValidationCode_VALID
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 	eventProducer.Ledger().NewFilteredBlock(
@@ -322,7 +322,7 @@ func checkCCEvent(t *testing.T, event *fab.CCEvent, expectedCCID string, expecte
 	}
 }
 
-func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID string, expectedCode pb.TxValidationCode) {
+func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID fab.TransactionID, expectedCode pb.TxValidationCode) {
 	if event.TxID != expectedTxID {
 		t.Fatalf("expecting event for TxID [%s] but received event for TxID [%s]", expectedTxID, event.TxID)
 	}

--- a/pkg/client/resmgmt/resmgmt.go
+++ b/pkg/client/resmgmt/resmgmt.go
@@ -844,7 +844,7 @@ func (rc *Client) sendCCProposal(reqCtx reqContext.Context, ccProposalType chain
 func (rc *Client) sendTransactionAndCheckEvent(eventService fab.EventService, tp *fab.TransactionProposal, txProposalResponse []*fab.TransactionProposalResponse,
 	transac fab.Transactor, reqCtx reqContext.Context) (fab.TransactionID, error) {
 	// Register for commit event
-	reg, statusNotifier, err := eventService.RegisterTxStatusEvent(string(tp.TxnID))
+	reg, statusNotifier, err := eventService.RegisterTxStatusEvent(tp.TxnID)
 	if err != nil {
 		return tp.TxnID, errors.WithMessage(err, "error registering for TxStatus event")
 	}
@@ -861,9 +861,9 @@ func (rc *Client) sendTransactionAndCheckEvent(eventService fab.EventService, tp
 	select {
 	case txStatus := <-statusNotifier:
 		if txStatus.TxValidationCode == pb.TxValidationCode_VALID {
-			return fab.TransactionID(txStatus.TxID), nil
+			return txStatus.TxID, nil
 		}
-		return fab.TransactionID(txStatus.TxID), status.New(status.EventServerStatus, int32(txStatus.TxValidationCode), "instantiateOrUpgradeCC failed", nil)
+		return txStatus.TxID, status.New(status.EventServerStatus, int32(txStatus.TxValidationCode), "instantiateOrUpgradeCC failed", nil)
 	case <-reqCtx.Done():
 		return tp.TxnID, errors.New("instantiateOrUpgradeCC timed out or cancelled")
 	}

--- a/pkg/common/providers/fab/eventservice.go
+++ b/pkg/common/providers/fab/eventservice.go
@@ -30,7 +30,7 @@ type FilteredBlockEvent struct {
 // TxStatusEvent contains the data for a transaction status event
 type TxStatusEvent struct {
 	// TxID is the ID of the transaction in which the event was set
-	TxID string
+	TxID TransactionID
 	// TxValidationCode is the status code of the commit
 	TxValidationCode pb.TxValidationCode
 	// BlockNumber contains the block number in which the
@@ -43,7 +43,7 @@ type TxStatusEvent struct {
 // CCEvent contains the data for a chaincode event
 type CCEvent struct {
 	// TxID is the ID of the transaction in which the event was set
-	TxID string
+	TxID TransactionID
 	// ChaincodeID is the ID of the chaincode that set the event
 	ChaincodeID string
 	// EventName is the name of the chaincode event
@@ -96,7 +96,7 @@ type EventService interface {
 	// - txID is the transaction ID for which events are to be received
 	// - Returns the registration and a channel that is used to receive events. The channel
 	//   is closed when Unregister is called.
-	RegisterTxStatusEvent(txID string) (Registration, <-chan *TxStatusEvent, error)
+	RegisterTxStatusEvent(txID TransactionID) (Registration, <-chan *TxStatusEvent, error)
 
 	// Unregister removes the given registration and closes the event channel.
 	// - reg is the registration handle that was returned from one of the Register functions

--- a/pkg/fab/events/client/client_test.go
+++ b/pkg/fab/events/client/client_test.go
@@ -322,9 +322,9 @@ func TestFilteredBlockEvents(t *testing.T) {
 	}
 	defer eventClient.Unregister(registration2)
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	conn.Ledger().NewFilteredBlock(
@@ -401,18 +401,18 @@ func TestBlockAndFilteredBlockEvents(t *testing.T) {
 	}
 	defer eventClient.Unregister(breg)
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	tx1 := &pb.FilteredTransaction{
-		Txid:             txID1,
+		Txid:             string(txID1),
 		TxValidationCode: txCode1,
 	}
 
 	tx2 := &pb.FilteredTransaction{
-		Txid:             txID2,
+		Txid:             string(txID2),
 		TxValidationCode: txCode2,
 	}
 
@@ -470,9 +470,9 @@ func TestTxStatusEvents(t *testing.T) {
 	}
 	defer eventClient.Close()
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	if _, _, err1 := eventClient.RegisterTxStatusEvent(""); err1 == nil {
@@ -508,7 +508,7 @@ func TestTxStatusEvents(t *testing.T) {
 	checkTxStatusEvents(t, eventch1, eventch2, txID1, txID2, txCode1, txCode2)
 }
 
-func checkTxStatusEvents(t *testing.T, eventch1 <-chan *fab.TxStatusEvent, eventch2 <-chan *fab.TxStatusEvent, txID1, txID2 string, txCode1, txCode2 pb.TxValidationCode) {
+func checkTxStatusEvents(t *testing.T, eventch1 <-chan *fab.TxStatusEvent, eventch2 <-chan *fab.TxStatusEvent, txID1, txID2 fab.TransactionID, txCode1, txCode2 pb.TxValidationCode) {
 	numExpected := 2
 	numReceived := 0
 	done := false
@@ -833,7 +833,7 @@ func TestConcurrentEvents(t *testing.T) {
 	// Produce some block events
 	go func() {
 		for i := 0; i < numEvents; i++ {
-			txID := fmt.Sprintf("txid_tx_%d", i)
+			txID := fab.TransactionID(fmt.Sprintf("txid_tx_%d", i))
 			conn.Ledger().NewBlock(channelID,
 				servicemocks.NewTransaction(txID, pb.TxValidationCode_VALID, cb.HeaderType_CONFIG_UPDATE),
 			)
@@ -1010,7 +1010,7 @@ func txStatusTest(eventClient *Client, ledger servicemocks.Ledger, channelID str
 	var receivedEvents int
 
 	for i := 0; i < expected; i++ {
-		txID := fmt.Sprintf("TxID_%d", i)
+		txID := fab.TransactionID(fmt.Sprintf("TxID_%d", i))
 		go func() {
 			defer wg.Done()
 
@@ -1436,7 +1436,7 @@ func checkFilteredBlock(t *testing.T, fblock *pb.FilteredBlock, expectedChannelI
 	}
 }
 
-func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID string, expectedCode pb.TxValidationCode) {
+func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID fab.TransactionID, expectedCode pb.TxValidationCode) {
 	if event.TxID != expectedTxID {
 		t.Fatalf("expecting event for TxID [%s] but received event for TxID [%s]", expectedTxID, event.TxID)
 	}

--- a/pkg/fab/events/service/dispatcher/dispatcher_test.go
+++ b/pkg/fab/events/service/dispatcher/dispatcher_test.go
@@ -124,9 +124,9 @@ func TestBlockEventsWithFilter(t *testing.T) {
 		t.Fatalf("Error registering for filtered block events: %s", err)
 	}
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	eventProducer := servicemocks.NewBlockProducer()
@@ -208,9 +208,9 @@ func TestFilteredBlockEvents(t *testing.T) {
 		t.Fatalf("Error registering for filtered block events: %s", err)
 	}
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	dispatcherEventch <- NewFilteredBlockEvent(servicemocks.NewBlockProducer().NewFilteredBlock(
@@ -285,9 +285,9 @@ func TestBlockAndFilteredBlockEvents(t *testing.T) {
 		t.Fatalf("Error registering for filtered block events: %s", err)
 	}
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	dispatcherEventch <- NewBlockEvent(servicemocks.NewBlockProducer().NewBlock(channelID,
@@ -351,9 +351,9 @@ func TestTxStatusEvents(t *testing.T) {
 		t.Fatalf("Error getting event channel from dispatcher: %s", err)
 	}
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	regch := make(chan fab.Registration)
@@ -408,7 +408,7 @@ func TestTxStatusEvents(t *testing.T) {
 	}
 }
 
-func registerEvent(dispatcherEventch chan<- interface{}, txID string, regch chan fab.Registration, errch chan error, t *testing.T) (chan *fab.TxStatusEvent, chan<- interface{}, fab.Registration) {
+func registerEvent(dispatcherEventch chan<- interface{}, txID fab.TransactionID, regch chan fab.Registration, errch chan error, t *testing.T) (chan *fab.TxStatusEvent, chan<- interface{}, fab.Registration) {
 	eventch := make(chan *fab.TxStatusEvent, 10)
 	dispatcherEventch <- NewRegisterTxStatusEvent(txID, eventch, regch, errch)
 	var reg fab.Registration
@@ -420,7 +420,7 @@ func registerEvent(dispatcherEventch chan<- interface{}, txID string, regch chan
 	return eventch, dispatcherEventch, reg
 }
 
-func checkTxStatusEvents(fblockEvent *fab.FilteredBlockEvent, eventch1 chan *fab.TxStatusEvent, t *testing.T, txID1 string, txCode1 pb.TxValidationCode, eventch2 chan *fab.TxStatusEvent, txID2 string, txCode2 pb.TxValidationCode) {
+func checkTxStatusEvents(fblockEvent *fab.FilteredBlockEvent, eventch1 chan *fab.TxStatusEvent, t *testing.T, txID1 fab.TransactionID, txCode1 pb.TxValidationCode, eventch2 chan *fab.TxStatusEvent, txID2 fab.TransactionID, txCode2 pb.TxValidationCode) {
 	expectedBlockNumber := fblockEvent.FilteredBlock.Number
 	numExpected := 2
 	numReceived := 0
@@ -451,7 +451,7 @@ func checkTxStatusEvents(fblockEvent *fab.FilteredBlockEvent, eventch1 chan *fab
 	}
 }
 
-func checkEventCh1(ok bool, t *testing.T, event *fab.TxStatusEvent, txID1 string, txCode1 pb.TxValidationCode, numReceived int, expectedBlockNumber uint64) int {
+func checkEventCh1(ok bool, t *testing.T, event *fab.TxStatusEvent, txID1 fab.TransactionID, txCode1 pb.TxValidationCode, numReceived int, expectedBlockNumber uint64) int {
 	if !ok {
 		t.Fatal("unexpected closed channel")
 	} else {
@@ -795,7 +795,7 @@ func checkEvent(eventch chan *RegistrationInfo, t *testing.T, totalRegistrations
 	}
 }
 
-func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID string, expectedCode pb.TxValidationCode) {
+func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID fab.TransactionID, expectedCode pb.TxValidationCode) {
 	if event.TxID != expectedTxID {
 		t.Fatalf("expecting event for TxID [%s] but received event for TxID [%s]", expectedTxID, event.TxID)
 	}
@@ -865,7 +865,7 @@ type transferFunc func(dispatcher *Dispatcher) (fab.EventSnapshot, error)
 
 func testTransferSnapshot(t *testing.T, transferFunc transferFunc) {
 	channelID := "testchannel"
-	txID := "tx_1234"
+	txID := fab.TransactionID("tx_1234")
 	ccID := "cc_id"
 	eventID := "event_1"
 
@@ -977,7 +977,7 @@ func ensureCCEvent(t *testing.T, eventch <-chan *fab.CCEvent, ccID, eventName st
 	}
 }
 
-func ensureTxStatusEvent(t *testing.T, eventch <-chan *fab.TxStatusEvent, txID string) {
+func ensureTxStatusEvent(t *testing.T, eventch <-chan *fab.TxStatusEvent, txID fab.TransactionID) {
 	select {
 	case txEvent, ok := <-eventch:
 		require.True(t, ok, "unexpected closed channel")

--- a/pkg/fab/events/service/dispatcher/events.go
+++ b/pkg/fab/events/service/dispatcher/events.go
@@ -120,7 +120,7 @@ func NewRegisterChaincodeEvent(ccID, eventFilter string, eventch chan<- *fab.CCE
 }
 
 // NewRegisterTxStatusEvent creates a new RegisterTxStatusEvent
-func NewRegisterTxStatusEvent(txID string, eventch chan<- *fab.TxStatusEvent, respch chan<- fab.Registration, errCh chan<- error) *RegisterTxStatusEvent {
+func NewRegisterTxStatusEvent(txID fab.TransactionID, eventch chan<- *fab.TxStatusEvent, respch chan<- fab.Registration, errCh chan<- error) *RegisterTxStatusEvent {
 	return &RegisterTxStatusEvent{
 		Reg:           &TxStatusReg{TxID: txID, Eventch: eventch},
 		RegisterEvent: NewRegisterEvent(respch, errCh),
@@ -152,7 +152,7 @@ func NewFilteredBlockEvent(fblock *pb.FilteredBlock, sourceURL string) *fab.Filt
 }
 
 // NewChaincodeEvent creates a new ChaincodeEvent
-func NewChaincodeEvent(chaincodeID, eventName, txID string, payload []byte, blockNum uint64, sourceURL string) *fab.CCEvent {
+func NewChaincodeEvent(chaincodeID, eventName string, txID fab.TransactionID, payload []byte, blockNum uint64, sourceURL string) *fab.CCEvent {
 	return &fab.CCEvent{
 		ChaincodeID: chaincodeID,
 		EventName:   eventName,
@@ -164,7 +164,7 @@ func NewChaincodeEvent(chaincodeID, eventName, txID string, payload []byte, bloc
 }
 
 // NewTxStatusEvent creates a new TxStatusEvent
-func NewTxStatusEvent(txID string, txValidationCode pb.TxValidationCode, blockNum uint64, sourceURL string) *fab.TxStatusEvent {
+func NewTxStatusEvent(txID fab.TransactionID, txValidationCode pb.TxValidationCode, blockNum uint64, sourceURL string) *fab.TxStatusEvent {
 	return &fab.TxStatusEvent{
 		TxID:             txID,
 		TxValidationCode: txValidationCode,

--- a/pkg/fab/events/service/dispatcher/registrations.go
+++ b/pkg/fab/events/service/dispatcher/registrations.go
@@ -34,7 +34,7 @@ type ChaincodeReg struct {
 
 // TxStatusReg contains the data for a transaction status registration
 type TxStatusReg struct {
-	TxID    string
+	TxID    fab.TransactionID
 	Eventch chan<- *fab.TxStatusEvent
 }
 

--- a/pkg/fab/events/service/mocks/mockevents.go
+++ b/pkg/fab/events/service/mocks/mockevents.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 )
 
 // NewBlock returns a new mock block initialized with the given channel
@@ -38,7 +39,7 @@ func NewBlock(channelID string, transactions ...*TxInfo) *cb.Block {
 // TxInfo contains the data necessary to
 // construct a mock transaction
 type TxInfo struct {
-	TxID             string
+	TxID             fab.TransactionID
 	TxValidationCode pb.TxValidationCode
 	HeaderType       cb.HeaderType
 	ChaincodeID      string
@@ -47,7 +48,7 @@ type TxInfo struct {
 }
 
 // NewTransaction creates a new transaction
-func NewTransaction(txID string, txValidationCode pb.TxValidationCode, headerType cb.HeaderType) *TxInfo {
+func NewTransaction(txID fab.TransactionID, txValidationCode pb.TxValidationCode, headerType cb.HeaderType) *TxInfo {
 	return &TxInfo{
 		TxID:             txID,
 		TxValidationCode: txValidationCode,
@@ -56,7 +57,7 @@ func NewTransaction(txID string, txValidationCode pb.TxValidationCode, headerTyp
 }
 
 // NewTransactionWithCCEvent creates a new transaction with the given chaincode event
-func NewTransactionWithCCEvent(txID string, txValidationCode pb.TxValidationCode, ccID string, eventName string, payload []byte) *TxInfo {
+func NewTransactionWithCCEvent(txID fab.TransactionID, txValidationCode pb.TxValidationCode, ccID string, eventName string, payload []byte) *TxInfo {
 	return &TxInfo{
 		TxID:             txID,
 		TxValidationCode: txValidationCode,
@@ -77,9 +78,9 @@ func NewFilteredBlock(channelID string, filteredTx ...*pb.FilteredTransaction) *
 }
 
 // NewFilteredTx returns a new mock filtered transaction
-func NewFilteredTx(txID string, txValidationCode pb.TxValidationCode) *pb.FilteredTransaction {
+func NewFilteredTx(txID fab.TransactionID, txValidationCode pb.TxValidationCode) *pb.FilteredTransaction {
 	return &pb.FilteredTransaction{
-		Txid:             txID,
+		Txid:             string(txID),
 		TxValidationCode: txValidationCode,
 	}
 }
@@ -116,7 +117,7 @@ func newEnvelope(channelID string, txInfo *TxInfo) *cb.Envelope {
 
 	channelHeader := &cb.ChannelHeader{
 		ChannelId: channelID,
-		TxId:      txInfo.TxID,
+		TxId:      string(txInfo.TxID),
 		Type:      int32(txInfo.HeaderType),
 	}
 	channelHeaderBytes, err := proto.Marshal(channelHeader)
@@ -140,9 +141,9 @@ func newEnvelope(channelID string, txInfo *TxInfo) *cb.Envelope {
 	}
 }
 
-func newTxAction(txID string, ccID string, eventName string, payload []byte) *pb.TransactionAction {
+func newTxAction(txID fab.TransactionID, ccID string, eventName string, payload []byte) *pb.TransactionAction {
 	ccEvent := &pb.ChaincodeEvent{
-		TxId:        txID,
+		TxId:        string(txID),
 		ChaincodeId: ccID,
 		EventName:   eventName,
 		Payload:     payload,

--- a/pkg/fab/events/service/service.go
+++ b/pkg/fab/events/service/service.go
@@ -240,7 +240,7 @@ func (s *Service) RegisterChaincodeEvent(ccID, eventFilter string) (fab.Registra
 // RegisterTxStatusEvent registers for transaction status events. If the client is not authorized to receive
 // transaction status events then an error is returned.
 // - txID is the transaction ID for which events are to be received
-func (s *Service) RegisterTxStatusEvent(txID string) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
+func (s *Service) RegisterTxStatusEvent(txID fab.TransactionID) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
 	if txID == "" {
 		return nil, nil, errors.New("txID must be provided")
 	}

--- a/pkg/fab/events/service/service_test.go
+++ b/pkg/fab/events/service/service_test.go
@@ -93,9 +93,9 @@ func TestBlockEventsWithFilter(t *testing.T) {
 	}
 	defer eventService.Unregister(fbreg)
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	eventProducer.Ledger().NewBlock(channelID,
@@ -156,9 +156,9 @@ func TestFilteredBlockEvents(t *testing.T) {
 	}
 	defer eventService.Unregister(registration)
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	eventProducer.Ledger().NewFilteredBlock(
@@ -204,9 +204,9 @@ func TestBlockAndFilteredBlockEvents(t *testing.T) {
 	}
 	defer eventService.Unregister(fbreg)
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	eventProducer.Ledger().NewBlock(channelID,
@@ -257,9 +257,9 @@ func TestTxStatusEvents(t *testing.T) {
 	defer eventProducer.Close()
 	defer eventService.Stop()
 
-	txID1 := "1234"
+	txID1 := fab.TransactionID("1234")
 	txCode1 := pb.TxValidationCode_VALID
-	txID2 := "5678"
+	txID2 := fab.TransactionID("5678")
 	txCode2 := pb.TxValidationCode_ENDORSEMENT_POLICY_FAILURE
 
 	if _, _, err1 := eventService.RegisterTxStatusEvent(""); err1 == nil {
@@ -296,7 +296,7 @@ func TestTxStatusEvents(t *testing.T) {
 	checkTxStatusEvents(eventch1, t, txID1, txCode1, eventch2, txID2, txCode2)
 }
 
-func checkTxStatusEvents(eventch1 <-chan *fab.TxStatusEvent, t *testing.T, txID1 string, txCode1 pb.TxValidationCode, eventch2 <-chan *fab.TxStatusEvent, txID2 string, txCode2 pb.TxValidationCode) {
+func checkTxStatusEvents(eventch1 <-chan *fab.TxStatusEvent, t *testing.T, txID1 fab.TransactionID, txCode1 pb.TxValidationCode, eventch2 <-chan *fab.TxStatusEvent, txID2 fab.TransactionID, txCode2 pb.TxValidationCode) {
 	numExpected := 2
 	numReceived := 0
 	done := false
@@ -466,7 +466,7 @@ func testConcurrentBlockEvents(channelID string, numEvents uint, eventService fa
 		var i uint
 		for i = 0; i < numEvents+10; i++ {
 			eventProducer.Ledger().NewBlock(channelID,
-				servicemocks.NewTransaction(fmt.Sprintf("txid_fb_%d", i), pb.TxValidationCode_VALID, cb.HeaderType_CONFIG_UPDATE),
+				servicemocks.NewTransaction(fab.TransactionID(fmt.Sprintf("txid_fb_%d", i)), pb.TxValidationCode_VALID, cb.HeaderType_CONFIG_UPDATE),
 			)
 		}
 	}()
@@ -544,7 +544,7 @@ func sendNewBlock(numEvents uint, conn *servicemocks.MockProducer, channelID str
 		for _ = 0; i < numEvents; i++ {
 			conn.Ledger().NewBlock(channelID,
 				servicemocks.NewTransaction(
-					fmt.Sprintf("txid_fb_%d", i), pb.TxValidationCode_VALID, cb.HeaderType_CONFIG_UPDATE),
+					fab.TransactionID(fmt.Sprintf("txid_fb_%d", i)), pb.TxValidationCode_VALID, cb.HeaderType_CONFIG_UPDATE),
 			)
 		}
 	}()
@@ -564,7 +564,7 @@ func testConcurrentCCEvents(channelID string, numEvents uint, eventService fab.E
 		var i uint
 		for i = 0; i < numEvents+10; i++ {
 			conn.Ledger().NewBlock(channelID,
-				servicemocks.NewTransactionWithCCEvent(fmt.Sprintf("txid_cc_%d", i), pb.TxValidationCode_VALID, ccID, event1, nil),
+				servicemocks.NewTransactionWithCCEvent(fab.TransactionID(fmt.Sprintf("txid_cc_%d", i)), pb.TxValidationCode_VALID, ccID, event1, nil),
 			)
 		}
 	}()
@@ -604,7 +604,7 @@ func testConcurrentTxStatusEvents(channelID string, numEvents uint, eventService
 
 	var receivedEvents uint32
 	for i := 0; i < int(numEvents); i++ {
-		txID := fmt.Sprintf("txid_tx_%d", i)
+		txID := fab.TransactionID(fmt.Sprintf("txid_tx_%d", i))
 		go func() {
 			defer wg.Done()
 
@@ -646,7 +646,7 @@ func testConcurrentTxStatusEvents(channelID string, numEvents uint, eventService
 	return nil
 }
 
-func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID string, expectedCode pb.TxValidationCode) {
+func checkTxStatusEvent(t *testing.T, event *fab.TxStatusEvent, expectedTxID fab.TransactionID, expectedCode pb.TxValidationCode) {
 	if event.TxID != expectedTxID {
 		t.Fatalf("expecting event for TxID [%s] but received event for TxID [%s]", expectedTxID, event.TxID)
 	}

--- a/pkg/fab/mocks/mockbroadcastserver.go
+++ b/pkg/fab/mocks/mockbroadcastserver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	po "github.com/hyperledger/fabric-protos-go/orderer"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/util/test"
 	"google.golang.org/grpc"
@@ -106,7 +107,7 @@ func (m *MockBroadcastServer) mockBlockDelivery(payload []byte) error {
 			m.delMtx.Lock()
 			defer m.delMtx.Unlock()
 			block := mocks.NewBlock(chdr.ChannelId,
-				mocks.NewTransaction(chdr.TxId, pb.TxValidationCode_VALID, common.HeaderType_MESSAGE),
+				mocks.NewTransaction(fab.TransactionID(chdr.TxId), pb.TxValidationCode_VALID, common.HeaderType_MESSAGE),
 			)
 			// m.blkNum is used by FilteredBlock only
 
@@ -117,7 +118,7 @@ func (m *MockBroadcastServer) mockBlockDelivery(payload []byte) error {
 			m.filteredDelMtx.Lock()
 			defer m.filteredDelMtx.Unlock()
 			filteredBlock := mocks.NewFilteredBlock(chdr.ChannelId,
-				mocks.NewFilteredTx(chdr.TxId, pb.TxValidationCode_VALID),
+				mocks.NewFilteredTx(fab.TransactionID(chdr.TxId), pb.TxValidationCode_VALID),
 			)
 			// increase m.blkNum to mock adding of filtered blocks to the ledger
 			m.blkNum++

--- a/pkg/fab/mocks/mockeventservice.go
+++ b/pkg/fab/mocks/mockeventservice.go
@@ -58,7 +58,7 @@ func (m *MockEventService) RegisterChaincodeEvent(ccID, eventFilter string) (fab
 }
 
 // RegisterTxStatusEvent registers for transaction status events.
-func (m *MockEventService) RegisterTxStatusEvent(txID string) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
+func (m *MockEventService) RegisterTxStatusEvent(txID fab.TransactionID) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
 	eventCh := make(chan *fab.TxStatusEvent)
 	reg := &dispatcher.TxStatusReg{
 		Eventch: eventCh,

--- a/pkg/fabsdk/provider/chpvdr/eventserviceref.go
+++ b/pkg/fabsdk/provider/chpvdr/eventserviceref.go
@@ -96,7 +96,7 @@ func (ref *EventClientRef) RegisterChaincodeEvent(ccID, eventFilter string) (fab
 }
 
 // RegisterTxStatusEvent registers for transaction status events.
-func (ref *EventClientRef) RegisterTxStatusEvent(txID string) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
+func (ref *EventClientRef) RegisterTxStatusEvent(txID fab.TransactionID) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
 	service, err := ref.get()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/gateway/transaction.go
+++ b/pkg/gateway/transaction.go
@@ -151,7 +151,7 @@ func (c *commitTxHandler) Handle(requestContext *invoke.RequestContext, clientCo
 	txnID := requestContext.Response.TransactionID
 
 	//Register Tx event
-	reg, statusNotifier, err := clientContext.EventService.RegisterTxStatusEvent(string(txnID)) // TODO: Change func to use TransactionID instead of string
+	reg, statusNotifier, err := clientContext.EventService.RegisterTxStatusEvent(txnID)
 	if err != nil {
 		requestContext.Error = errors.Wrap(err, "error registering for TxStatus event")
 		return

--- a/test/integration/pkg/client/channel/channel_client_test.go
+++ b/test/integration/pkg/client/channel/channel_client_test.go
@@ -493,7 +493,7 @@ func testChaincodeEvent(t *testing.T, chClient *channel.Client, args [][]byte, c
 	select {
 	case ccEvent := <-notifier:
 		t.Logf("Received cc event: %#v", ccEvent)
-		if ccEvent.TxID != string(response.TransactionID) {
+		if ccEvent.TxID != response.TransactionID {
 			t.Fatalf("CCEvent(%s) and Execute(%s) transaction IDs don't match", ccEvent.TxID, string(response.TransactionID))
 		}
 	case <-time.After(time.Second * 20):
@@ -573,7 +573,7 @@ func testChaincodeEventListener(t *testing.T, ccID string, chClient *channel.Cli
 	select {
 	case ccEvent := <-notifier:
 		t.Logf("Received cc event: %#v", ccEvent)
-		if ccEvent.TxID != string(response.TransactionID) {
+		if ccEvent.TxID != response.TransactionID {
 			t.Fatalf("CCEvent(%s) and Execute(%s) transaction IDs don't match", ccEvent.TxID, string(response.TransactionID))
 		}
 	case <-time.After(time.Second * 20):

--- a/test/integration/pkg/client/channel/channel_client_test.go
+++ b/test/integration/pkg/client/channel/channel_client_test.go
@@ -550,7 +550,7 @@ func testMultipleClientChaincodeEvent(t *testing.T, channelID string, chainCodeI
 	case <-time.After(time.Second * 20):
 		t.Fatalf("Did NOT receive CC event for eventId(%s)\n", eventID)
 	}
-	assert.Equal(t, string(txID), ccEvent.TxID, "mismatched ccEvent.TxID")
+	assert.Equal(t, txID, ccEvent.TxID, "mismatched ccEvent.TxID")
 }
 
 func testChaincodeEventListener(t *testing.T, ccID string, chClient *channel.Client, listener *channel.Client, args [][]byte) {

--- a/test/integration/pkg/client/event/events_client_test.go
+++ b/test/integration/pkg/client/event/events_client_test.go
@@ -111,7 +111,7 @@ func testCCEvent(ccID string, chClient *channel.Client, eventClient *event.Clien
 		if !expectPayload && string(ccEvent.Payload[:]) != "" {
 			t.Fatalf("Expected empty payload, got %s", ccEvent.Payload[:])
 		}
-		if ccEvent.TxID != string(response.TransactionID) {
+		if ccEvent.TxID != response.TransactionID {
 			t.Fatalf("CCEvent(%s) and Execute(%s) transaction IDs don't match", ccEvent.TxID, string(response.TransactionID))
 		}
 	case <-time.After(time.Second * 20):

--- a/test/integration/pkg/fab/eventclient_test.go
+++ b/test/integration/pkg/fab/eventclient_test.go
@@ -127,7 +127,7 @@ func testEventService(t *testing.T, testSetup *integration.BaseSetupImpl, sdk *f
 	}
 }
 
-func sendTxProposal(sdk *fabsdk.FabricSDK, testSetup *integration.BaseSetupImpl, t *testing.T, transactor fab.Transactor, chainCodeID string, args [][]byte) ([]*fab.TransactionProposalResponse, *fab.TransactionProposal, string) {
+func sendTxProposal(sdk *fabsdk.FabricSDK, testSetup *integration.BaseSetupImpl, t *testing.T, transactor fab.Transactor, chainCodeID string, args [][]byte) ([]*fab.TransactionProposalResponse, *fab.TransactionProposal, fab.TransactionID) {
 	peers, err := getProposalProcessors(sdk, "Admin", testSetup.OrgID, testSetup.Targets)
 	require.Nil(t, err, "creating peers failed")
 	tpResponses, prop, err := createAndSendTransactionProposal(
@@ -141,11 +141,11 @@ func sendTxProposal(sdk *fabsdk.FabricSDK, testSetup *integration.BaseSetupImpl,
 	if err != nil {
 		t.Fatalf("CreateAndSendTransactionProposal return error: %s", err)
 	}
-	txID := string(prop.TxnID)
+	txID := prop.TxnID
 	return tpResponses, prop, txID
 }
 
-func checkTxStatusEvent(wg *sync.WaitGroup, txstatusch <-chan *fab.TxStatusEvent, t *testing.T, numReceived *uint32, txID string) {
+func checkTxStatusEvent(wg *sync.WaitGroup, txstatusch <-chan *fab.TxStatusEvent, t *testing.T, numReceived *uint32, txID fab.TransactionID) {
 	defer wg.Done()
 	select {
 	case txStatus, ok := <-txstatusch:
@@ -153,7 +153,7 @@ func checkTxStatusEvent(wg *sync.WaitGroup, txstatusch <-chan *fab.TxStatusEvent
 			test.Failf(t, "unexpected closed channel while waiting for Tx Status event")
 		}
 		t.Logf("Received Tx Status event: %#v", txStatus)
-		if txStatus.TxID != string(txID) {
+		if txStatus.TxID != txID {
 			test.Failf(t, "Expecting event for TxID [%s] but got event for TxID [%s]", txID, txStatus.TxID)
 		}
 		if txStatus.SourceURL == "" {
@@ -202,7 +202,7 @@ func checkCCEvent(wg *sync.WaitGroup, cceventch <-chan *fab.CCEvent, t *testing.
 	}
 }
 
-func checkFilteredBlockEvent(wg *sync.WaitGroup, fbeventch <-chan *fab.FilteredBlockEvent, t *testing.T, numReceived *uint32, txID string) {
+func checkFilteredBlockEvent(wg *sync.WaitGroup, fbeventch <-chan *fab.FilteredBlockEvent, t *testing.T, numReceived *uint32, txID fab.TransactionID) {
 	defer wg.Done()
 	for {
 		select {


### PR DESCRIPTION
Remove a TODO

>  TODO: Change func to use TransactionID instead of string

Signed-off-by: naeemo <370552604@qq.com>