### PR TITLE
[FABG-1012] Retry on private data dissemination error

### DIFF
--- a/pkg/client/common/mocks/mocktransactor.go
+++ b/pkg/client/common/mocks/mocktransactor.go
@@ -21,6 +21,7 @@ type MockTransactor struct {
 	Ctx       context.Client
 	ChannelID string
 	Orderers  []fab.Orderer
+	Err       error
 }
 
 // CreateTransactionHeader creates a Transaction Header based on the current context.
@@ -35,6 +36,10 @@ func (t *MockTransactor) CreateTransactionHeader(opts ...fab.TxnHeaderOpt) (fab.
 
 // SendTransactionProposal sends a TransactionProposal to the target peers.
 func (t *MockTransactor) SendTransactionProposal(proposal *fab.TransactionProposal, targets []fab.ProposalProcessor) ([]*fab.TransactionProposalResponse, error) {
+	if t.Err != nil {
+		return nil, t.Err
+	}
+
 	rqtx, cancel := contextImpl.NewRequest(t.Ctx, contextImpl.WithTimeout(10*time.Second))
 	defer cancel()
 	return txn.SendProposal(rqtx, proposal, targets)

--- a/pkg/common/errors/retry/defaults.go
+++ b/pkg/common/errors/retry/defaults.go
@@ -135,6 +135,7 @@ var ChannelClientRetryableCodes = map[status.Group][]status.Code{
 	status.EndorserServerStatus: {
 		status.Code(common.Status_SERVICE_UNAVAILABLE),
 		status.Code(common.Status_INTERNAL_SERVER_ERROR),
+		status.PvtDataDisseminationFailed,
 	},
 	status.OrdererClientStatus: {
 		status.ConnectionFailed,

--- a/pkg/common/errors/status/codes.go
+++ b/pkg/common/errors/status/codes.go
@@ -57,6 +57,9 @@ const (
 
 	// ChaincodeNameNotFound indicates that an that an attempt was made to invoke a chaincode that's not yet initialized
 	ChaincodeNameNotFound Code = 23
+
+	// PvtDataDisseminationFailed indicates that Gossip failed to disseminate private data to the required number of peers
+	PvtDataDisseminationFailed Code = 24
 )
 
 // CodeName maps the codes in this packages to human-readable strings
@@ -74,6 +77,7 @@ var CodeName = map[int32]string{
 	11: "QUERY_ENDORSERS",
 	12: "GENERIC_TRANSIENT",
 	23: "CHAINCODE_NAME_NOT_FOUND",
+	24: "PRIVATE_DATA_DISSEMINATION_FAILED",
 }
 
 // ToInt32 cast to int32


### PR DESCRIPTION
The channel client now retries on error "failed to distribute private collection" since this is most likely a transient error.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>