### PR TITLE
[FABG-1008] Allows ecdsakey to return private key bytes

### DIFF
--- a/internal/github.com/hyperledger/fabric/bccsp/sw/ecdsakey.go
+++ b/internal/github.com/hyperledger/fabric/bccsp/sw/ecdsakey.go
@@ -24,6 +24,7 @@ import (
 	"crypto/elliptic"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 
@@ -31,13 +32,24 @@ import (
 )
 
 type ecdsaPrivateKey struct {
-	privKey *ecdsa.PrivateKey
+	privKey    *ecdsa.PrivateKey
+	exportable bool
 }
 
 // Bytes converts this key to its byte representation,
 // if this operation is allowed.
 func (k *ecdsaPrivateKey) Bytes() ([]byte, error) {
-	return nil, errors.New("Not supported.")
+	if !k.exportable {
+		return nil, errors.New("not supported")
+	}
+
+	x509Encoded, err := x509.MarshalECPrivateKey(k.privKey)
+	if err != nil {
+		return nil, err
+	}
+	pemEncoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509Encoded})
+
+	return pemEncoded, nil
 }
 
 // SKI returns the subject key identifier of this key.

--- a/internal/github.com/hyperledger/fabric/bccsp/sw/fileks.go
+++ b/internal/github.com/hyperledger/fabric/bccsp/sw/fileks.go
@@ -145,7 +145,7 @@ func (ks *fileBasedKeyStore) GetKey(ski []byte) (bccsp.Key, error) {
 
 		switch k := key.(type) {
 		case *ecdsa.PrivateKey:
-			return &ecdsaPrivateKey{k}, nil
+			return &ecdsaPrivateKey{k, true}, nil
 		default:
 			return nil, errors.New("secret key type not recognized")
 		}
@@ -227,7 +227,7 @@ func (ks *fileBasedKeyStore) searchKeystoreForSKI(ski []byte) (k bccsp.Key, err 
 
 		switch kk := key.(type) {
 		case *ecdsa.PrivateKey:
-			k = &ecdsaPrivateKey{kk}
+			k = &ecdsaPrivateKey{kk, true}
 		default:
 			continue
 		}

--- a/internal/github.com/hyperledger/fabric/bccsp/sw/keyderiv.go
+++ b/internal/github.com/hyperledger/fabric/bccsp/sw/keyderiv.go
@@ -122,7 +122,7 @@ func (kd *ecdsaPrivateKeyKeyDeriver) KeyDeriv(key bccsp.Key, opts bccsp.KeyDeriv
 		return nil, errors.New("Failed temporary public key IsOnCurve check.")
 	}
 
-	return &ecdsaPrivateKey{tempSK}, nil
+	return &ecdsaPrivateKey{tempSK, true}, nil
 }
 
 type aesPrivateKeyKeyDeriver struct {

--- a/internal/github.com/hyperledger/fabric/bccsp/sw/keygen.go
+++ b/internal/github.com/hyperledger/fabric/bccsp/sw/keygen.go
@@ -39,7 +39,7 @@ func (kg *ecdsaKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
 		return nil, fmt.Errorf("Failed generating ECDSA key for [%v]: [%s]", kg.curve, err)
 	}
 
-	return &ecdsaPrivateKey{privKey}, nil
+	return &ecdsaPrivateKey{privKey, true}, nil
 }
 
 type aesKeyGenerator struct {

--- a/internal/github.com/hyperledger/fabric/bccsp/sw/keyimport.go
+++ b/internal/github.com/hyperledger/fabric/bccsp/sw/keyimport.go
@@ -101,7 +101,7 @@ func (*ecdsaPrivateKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts bcc
 		return nil, errors.New("Failed casting to ECDSA private key. Invalid raw material.")
 	}
 
-	return &ecdsaPrivateKey{ecdsaSK}, nil
+	return &ecdsaPrivateKey{ecdsaSK, true}, nil
 }
 
 type ecdsaGoPublicKeyImportOptsKeyImporter struct{}

--- a/test/performance/go.mod
+++ b/test/performance/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/protobuf v1.3.3
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23
 	github.com/hyperledger/fabric-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/hyperledger/fabric-sdk-go/test/integration v0.0.0-20200909154308-842c4b3ea51e // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980

--- a/test/performance/go.sum
+++ b/test/performance/go.sum
@@ -76,6 +76,8 @@ github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e h1:9P
 github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23 h1:SEbB3yH4ISTGRifDamYXAst36gO2kM855ndMJlsv+pc=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
+github.com/hyperledger/fabric-sdk-go/test/integration v0.0.0-20200909154308-842c4b3ea51e h1:OgmeW+oiQEjjY25lMKK31AEfcw/+I2ncSW3y06tPMg4=
+github.com/hyperledger/fabric-sdk-go/test/integration v0.0.0-20200909154308-842c4b3ea51e/go.mod h1:pbWZ9ogxfoPuZ0Kv9M6hFcYPDGWft/EGgLoLrJPsawc=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
 github.com/jmoiron/sqlx v0.0.0-20180124204410-05cef0741ade/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=


### PR DESCRIPTION
While creating a Commercial Paper application using fabric-sdk-go, I cannot retrieve the ecdsakey private key bytes needed to create the x509Identity.  Calling the ```PrivateKey().Bytes()``` method throws a Not implemented error.  However, this same code in the fabric-skd-node happily returns the Byte array of the ecdsakey.

[FABG-1008](https://jira.hyperledger.org/browse/FABG-1008)

I created an [integration test](https://github.com/pplavetzki/fabric-sdk-go/blob/114930734db2ce97113bb7a0e68c3f84e54b5f02/test/integration/pkg/client/msp/identity_test.go#L219) to verify that it now allows the Bytes of the private key to be retrieved.



Signed-off-by: Paul Plavetzki <paul@pareidolia.io>