### PR TITLE
[FABG-1016] Remove PackageID field from check commit readiness request

### DIFF
--- a/pkg/client/resmgmt/lifecycleclient.go
+++ b/pkg/client/resmgmt/lifecycleclient.go
@@ -86,7 +86,6 @@ type LifecycleApprovedChaincodeDefinition struct {
 type LifecycleCheckCCCommitReadinessRequest struct {
 	Name                string                          `json:"name,omitempty"`
 	Version             string                          `json:"version,omitempty"`
-	PackageID           string                          `json:"package_id,omitempty"`
 	Sequence            int64                           `json:"sequence,omitempty"`
 	EndorsementPlugin   string                          `json:"endorsement_plugin,omitempty"`
 	ValidationPlugin    string                          `json:"validation_plugin,omitempty"`

--- a/pkg/client/resmgmt/lifecycleclient_test.go
+++ b/pkg/client/resmgmt/lifecycleclient_test.go
@@ -437,7 +437,6 @@ func TestClient_LifecycleQueryApprovedCC(t *testing.T) {
 }
 
 func TestClient_LifecycleCheckCCCommitReadiness(t *testing.T) {
-	const packageID = "pkg1"
 	const cc1 = "cc1"
 	const v1 = "v1"
 	const channel1 = "channel1"
@@ -452,10 +451,9 @@ func TestClient_LifecycleCheckCCCommitReadiness(t *testing.T) {
 	peer1 := &fcmocks.MockPeer{Payload: responseBytes}
 
 	req := LifecycleCheckCCCommitReadinessRequest{
-		Name:      cc1,
-		Version:   v1,
-		PackageID: packageID,
-		Sequence:  1,
+		Name:     cc1,
+		Version:  v1,
+		Sequence: 1,
 	}
 
 	ctx := setupTestContext("test", "Org1MSP")
@@ -505,9 +503,8 @@ func TestClient_LifecycleCheckCCCommitReadiness(t *testing.T) {
 		ctx.SetCustomChannelProvider(cp)
 
 		req := LifecycleCheckCCCommitReadinessRequest{
-			Version:   v1,
-			PackageID: packageID,
-			Sequence:  1,
+			Version:  v1,
+			Sequence: 1,
 		}
 
 		resp, err := rc.LifecycleCheckCCCommitReadiness(channel1, req, WithTargets(peer1))
@@ -519,9 +516,8 @@ func TestClient_LifecycleCheckCCCommitReadiness(t *testing.T) {
 		ctx.SetCustomChannelProvider(cp)
 
 		req := LifecycleCheckCCCommitReadinessRequest{
-			Name:      cc1,
-			PackageID: packageID,
-			Sequence:  1,
+			Name:     cc1,
+			Sequence: 1,
 		}
 
 		resp, err := rc.LifecycleCheckCCCommitReadiness(channel1, req, WithTargets(peer1))

--- a/pkg/fab/resource/lifecycle.go
+++ b/pkg/fab/resource/lifecycle.go
@@ -73,7 +73,6 @@ type CommitChaincodeRequest struct {
 type CheckChaincodeCommitReadinessRequest struct {
 	Name                string
 	Version             string
-	PackageID           string
 	Sequence            int64
 	EndorsementPlugin   string
 	ValidationPlugin    string

--- a/pkg/fab/resource/lifecycle_test.go
+++ b/pkg/fab/resource/lifecycle_test.go
@@ -591,26 +591,6 @@ func TestLifecycle_CreateCheckCommitReadinessProposal(t *testing.T) {
 		req := &CheckChaincodeCommitReadinessRequest{
 			Name:              "cc1",
 			Version:           "v1",
-			PackageID:         "pkg1",
-			Sequence:          1,
-			EndorsementPlugin: "eplugin",
-			ValidationPlugin:  "vplugin",
-			SignaturePolicy:   policydsl.AcceptAllPolicy,
-			CollectionConfig:  []*pb.CollectionConfig{},
-			InitRequired:      true,
-		}
-
-		p, err := lc.CreateCheckCommitReadinessProposal(&mocks.MockTransactionHeader{}, req)
-		require.NoError(t, err)
-		require.NotNil(t, p)
-		require.NotNil(t, p.Proposal)
-	})
-
-	t.Run("No package ID -> success", func(t *testing.T) {
-		req := &CheckChaincodeCommitReadinessRequest{
-			Name:              "cc1",
-			Version:           "v1",
-			PackageID:         "",
 			Sequence:          1,
 			EndorsementPlugin: "eplugin",
 			ValidationPlugin:  "vplugin",
@@ -664,7 +644,6 @@ func TestLifecycle_CreateCheckCommitReadinessProposal(t *testing.T) {
 		req := &CheckChaincodeCommitReadinessRequest{
 			Name:                "cc1",
 			Version:             "v1",
-			PackageID:           "",
 			Sequence:            1,
 			EndorsementPlugin:   "eplugin",
 			ValidationPlugin:    "vplugin",
@@ -691,7 +670,6 @@ func TestLifecycle_CreateCheckCommitReadinessProposal(t *testing.T) {
 		req := &CheckChaincodeCommitReadinessRequest{
 			Name:              "cc1",
 			Version:           "v1",
-			PackageID:         "",
 			Sequence:          1,
 			EndorsementPlugin: "eplugin",
 			ValidationPlugin:  "vplugin",

--- a/test/integration/e2e/end_to_end.go
+++ b/test/integration/e2e/end_to_end.go
@@ -258,7 +258,7 @@ func createCCLifecycle(t *testing.T, orgResMgmt *resmgmt.Client, sdk *fabsdk.Fab
 	queryApprovedCC(t, orgResMgmt)
 
 	// Check commit readiness
-	checkCCCommitReadiness(t, packageID, orgResMgmt)
+	checkCCCommitReadiness(t, orgResMgmt)
 
 	// Commit cc
 	commitCC(t, orgResMgmt)
@@ -348,12 +348,11 @@ func queryApprovedCC(t *testing.T, orgResMgmt *resmgmt.Client) {
 	require.NotNil(t, resp)
 }
 
-func checkCCCommitReadiness(t *testing.T, packageID string, orgResMgmt *resmgmt.Client) {
+func checkCCCommitReadiness(t *testing.T, orgResMgmt *resmgmt.Client) {
 	ccPolicy := policydsl.SignedByAnyMember([]string{"Org1MSP"})
 	req := resmgmt.LifecycleCheckCCCommitReadinessRequest{
 		Name:              ccID,
 		Version:           "0",
-		PackageID:         packageID,
 		EndorsementPlugin: "escc",
 		ValidationPlugin:  "vscc",
 		SignaturePolicy:   ccPolicy,

--- a/test/integration/e2e/orgs/multiple_orgs_test.go
+++ b/test/integration/e2e/orgs/multiple_orgs_test.go
@@ -718,7 +718,7 @@ func createCCLifecycle(t *testing.T, mc *multiorgContext, ccName, ccVersion stri
 	queryApprovedCC(t, ccName, sequence, channelID, mc)
 
 	// Check commit readiness
-	checkCCCommitReadiness(t, packageID, ccName, ccVersion, sequence, channelID, mc)
+	checkCCCommitReadiness(t, ccName, ccVersion, sequence, channelID, mc)
 
 	// Commit cc
 	commitCC(t, ccName, ccVersion, sequence, channelID, mc)
@@ -887,7 +887,7 @@ func queryApprovedCC(t *testing.T, ccName string, sequence int64, channelID stri
 
 }
 
-func checkCCCommitReadiness(t *testing.T, packageID string, ccName, ccVersion string, sequence int64, channelID string, mc *multiorgContext) {
+func checkCCCommitReadiness(t *testing.T, ccName, ccVersion string, sequence int64, channelID string, mc *multiorgContext) {
 
 	org1Peers, err := integration.DiscoverLocalPeers(mc.org1AdminClientContext, 2)
 	require.NoError(t, err)
@@ -898,7 +898,6 @@ func checkCCCommitReadiness(t *testing.T, packageID string, ccName, ccVersion st
 	req := resmgmt.LifecycleCheckCCCommitReadinessRequest{
 		Name:              ccName,
 		Version:           ccVersion,
-		PackageID:         packageID,
 		EndorsementPlugin: "escc",
 		ValidationPlugin:  "vscc",
 		SignaturePolicy:   ccPolicy,

--- a/test/integration/prepare.go
+++ b/test/integration/prepare.go
@@ -176,7 +176,7 @@ func PrepareExampleCCLc(sdk *fabsdk.FabricSDK, user fabsdk.ContextOption, orgNam
 		return errors.WithMessage(err, "QueryApprovedCC example chaincode failed")
 	}
 
-	err = CheckCCCommitReadiness(orgContexts, packageID, chaincodeID, exampleCCVersion, 1, channelID, ccPolicy)
+	err = CheckCCCommitReadiness(orgContexts, chaincodeID, exampleCCVersion, 1, channelID, ccPolicy)
 	if err != nil {
 		return errors.WithMessage(err, "CheckCCCommitReadiness example chaincode failed")
 	}
@@ -316,7 +316,7 @@ func queryApprovedCC(orgCtx *OrgContext, channelID string, p fabAPI.Peer, req re
 }
 
 // CheckCCCommitReadiness checkcommit the example CC on the given channel
-func CheckCCCommitReadiness(mc []*OrgContext, packageID string, ccName, ccVersion string, sequence int64, channelID string, ccPolicyStr string, collConfigs ...*pb.CollectionConfig) error {
+func CheckCCCommitReadiness(mc []*OrgContext, ccName, ccVersion string, sequence int64, channelID string, ccPolicyStr string, collConfigs ...*pb.CollectionConfig) error {
 	ccPolicy, err := policydsl.FromString(ccPolicyStr)
 	if err != nil {
 		return errors.Wrapf(err, "error creating CC policy [%s]", ccPolicyStr)
@@ -324,7 +324,6 @@ func CheckCCCommitReadiness(mc []*OrgContext, packageID string, ccName, ccVersio
 	req := resmgmt.LifecycleCheckCCCommitReadinessRequest{
 		Name:              ccName,
 		Version:           ccVersion,
-		PackageID:         packageID,
 		EndorsementPlugin: "escc",
 		ValidationPlugin:  "vscc",
 		SignaturePolicy:   ccPolicy,
@@ -589,7 +588,7 @@ func instantiateExampleChaincodeLc(sdk *fabsdk.FabricSDK, orgs []*OrgContext, ch
 		return errors.WithMessage(err, "QueryApprovedCC example chaincode failed")
 	}
 
-	err = CheckCCCommitReadiness(orgs, packageID, ccID, ccVersion, sequence, channelID, ccPolicy, collConfigs...)
+	err = CheckCCCommitReadiness(orgs, ccID, ccVersion, sequence, channelID, ccPolicy, collConfigs...)
 	if err != nil {
 		return errors.WithMessage(err, "CheckCCCommitReadiness example chaincode failed")
 	}


### PR DESCRIPTION
Removed an unecessary field, PackageID, from the struct, LifecycleCheckCCCommitReadinessRequest.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>