### PR TITLE
FABG-1018 TRANSIENT_FAILURE in SubmitTransaction

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -312,35 +312,26 @@ entityMatchers:
       urlSubstitutionExp: localhost:${2}
       sslTargetOverrideUrlSubstitutionExp: ${1}
       mappedHost: ${1}
-  peer:
+  orderer:
     - pattern: ([^:]+):(\\d+)
       urlSubstitutionExp: localhost:${2}
-      sslTargetOverrideUrlSubstitutionExp: localhost
+      sslTargetOverrideUrlSubstitutionExp: ${1}
       mappedHost: ${1}
 */
 func createLocalhostMappings() map[string][]map[string]string {
 	matchers := make(map[string][]map[string]string)
-	peerMappings := make([]map[string]string, 0)
-	ordererMappings := make([]map[string]string, 0)
-	mappedHost := "${1}"
+	mappings := make([]map[string]string, 0)
 
-	peerMapping := make(map[string]string)
-	peerMapping["pattern"] = "([^:]+):(\\d+)"
-	peerMapping["urlSubstitutionExp"] = "localhost:${2}"
-	peerMapping["sslTargetOverrideUrlSubstitutionExp"] = mappedHost
-	peerMapping["mappedHost"] = mappedHost
-	peerMappings = append(peerMappings, peerMapping)
+	mapping := make(map[string]string)
+	mapping["pattern"] = "([^:]+):(\\d+)"
+	mapping["urlSubstitutionExp"] = "localhost:${2}"
+	mapping["sslTargetOverrideUrlSubstitutionExp"] = "${1}"
+	mapping["mappedHost"] = "${1}"
+	mappings = append(mappings, mapping)
 
-	matchers["peer"] = peerMappings
+	matchers["peer"] = mappings
+	matchers["orderer"] = mappings
 
-	ordererMapping := make(map[string]string)
-	ordererMapping["pattern"] = "([^:]+):(\\d+)"
-	ordererMapping["urlSubstitutionExp"] = "localhost:${2}"
-	ordererMapping["sslTargetOverrideUrlSubstitutionExp"] = "localhost"
-	ordererMapping["mappedHost"] = mappedHost
-	ordererMappings = append(ordererMappings, ordererMapping)
-
-	matchers["orderer"] = ordererMappings
 	return matchers
 }
 

--- a/pkg/gateway/network.go
+++ b/pkg/gateway/network.go
@@ -48,6 +48,14 @@ func newNetwork(gateway *Gateway, channelProvider context.ChannelProvider) (*Net
 		return nil, errors.Wrap(err, "Failed to create new event client")
 	}
 
+	// the following is really to kick the discovery service into getting the TLScert
+	// so that subsequent SubmitTransaction can connect to the orderer
+	members, err := ctx.ChannelService().Membership()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to query channel membership")
+	}
+	members.ContainsMSP(gateway.mspid)
+
 	return &n, nil
 }
 

--- a/pkg/gateway/transaction.go
+++ b/pkg/gateway/transaction.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/pkg/errors"
@@ -113,6 +114,7 @@ func (txn *Transaction) Submit(args ...string) ([]byte, error) {
 		options = append(options, channel.WithTargetEndpoints(txn.endorsingPeers...))
 	}
 	options = append(options, channel.WithTimeout(fab.Execute, txn.contract.network.gateway.options.Timeout))
+	options = append(options, channel.WithRetry(retry.DefaultChannelOpts))
 
 	response, err := txn.contract.client.InvokeHandler(
 		newSubmitHandler(txn.eventch),

--- a/test/integration/pkg/gateway/gateway.go
+++ b/test/integration/pkg/gateway/gateway.go
@@ -70,6 +70,40 @@ func RunWithSDK(t *testing.T) {
 	testGateway(gw, t)
 }
 
+// RunWithSubmit integration test with SubmitTransaction immediately following channel init
+func RunWithSubmit(t *testing.T) {
+	configPath := integration.GetConfigPath("config_e2e.yaml")
+
+	sdk, err := fabsdk.New(config.FromFile(configPath))
+
+	if err != nil {
+		t.Fatalf("Failed to create new SDK: %s", err)
+	}
+
+	gw, err := gateway.Connect(
+		gateway.WithSDK(sdk),
+		gateway.WithUser("User1"),
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to create new Gateway: %s", err)
+	}
+	defer gw.Close()
+
+	nw, err := gw.GetNetwork(channelID)
+	if err != nil {
+		t.Fatalf("Failed to get network: %s", err)
+	}
+
+	contract := nw.GetContract(ccID)
+
+	_, err = contract.SubmitTransaction("invoke", "move", "a", "b", "1")
+
+	if err != nil {
+		t.Fatalf("Failed submit transaction: %s", err)
+	}
+}
+
 // RunWithWallet gateway/wallet integration test
 func RunWithWallet(t *testing.T) {
 	wallet := gateway.NewInMemoryWallet()

--- a/test/integration/pkg/gateway/gateway_test.go
+++ b/test/integration/pkg/gateway/gateway_test.go
@@ -22,6 +22,12 @@ func TestGatewayFromSDK(t *testing.T) {
 	})
 }
 
+func TestGatewayWithSubmit(t *testing.T) {
+	t.Run("Base", func(t *testing.T) {
+		RunWithSubmit(t)
+	})
+}
+
 func TestGatewayWithWallet(t *testing.T) {
 	t.Run("Base", func(t *testing.T) {
 		RunWithWallet(t)


### PR DESCRIPTION
When calling SubmitTransaction in the gateway package immediately following GetNetwork, it fails with TRANSIENT_FAILURE
The orderer log indicates bad TLS certificate.

This is a timing issue whereby the discovery information for the channel config was not available early enough.
Code had been added to force this to be read during channel initialization.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>