### PR TITLE
Fix see redundant connector caching.

### DIFF
--- a/pkg/fab/comm/connector.go
+++ b/pkg/fab/comm/connector.go
@@ -114,15 +114,13 @@ func (cc *CachingConnector) DialContext(ctx context.Context, target string, opts
 	logger.Debugf("DialContext: %s", target)
 
 	cc.lock.Lock()
-	c, ok := cc.loadConn(target)
-	if !ok {
-		createdConn, err := cc.createConn(ctx, target, opts...)
-		if err != nil {
-			cc.lock.Unlock()
-			return nil, errors.WithMessage(err, "connection creation failed")
-		}
-		c = createdConn
+
+	createdConn, err := cc.createConn(ctx, target, opts...)
+	if err != nil {
+		cc.lock.Unlock()
+		return nil, errors.WithMessage(err, "connection creation failed")
 	}
+	c := createdConn
 
 	cc.lock.Unlock()
 


### PR DESCRIPTION
don't need to call the loadConn function from the DialContext function because you call the loadConn function inside the createConn function and return a connection.