### PR TITLE
Fix Gateway Evaluate ignoring endpoint option

### DIFF
--- a/pkg/gateway/transaction.go
+++ b/pkg/gateway/transaction.go
@@ -86,6 +86,9 @@ func (txn *Transaction) Evaluate(args ...string) ([]byte, error) {
 	txn.request.Args = bytes
 
 	var options []channel.RequestOption
+	if txn.endorsingPeers != nil {
+		options = append(options, channel.WithTargetEndpoints(txn.endorsingPeers...))
+	}
 	options = append(options, channel.WithTimeout(fab.Query, txn.contract.network.gateway.options.Timeout))
 
 	response, err := txn.contract.client.Query(

--- a/pkg/gateway/transaction_test.go
+++ b/pkg/gateway/transaction_test.go
@@ -70,6 +70,7 @@ func TestTransactionOptions(t *testing.T) {
 		t.Fatalf("Incorrect endorsing peer: %s", endorsers[0])
 	}
 
+	txn.Evaluate("arg1", "arg2")
 	txn.Submit("arg1", "arg2")
 }
 


### PR DESCRIPTION
This PR fixes the issue [FABG-1019](https://jira.hyperledger.org/browse/FABG-1019). The current implementation of
Transaction Evalaute ignores the endorsing peers option when set. This
leads to unexpected behavor when txn object is used to perform evaluate
and submit.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>