### PR TITLE
[FABG-1021] Add properties to Peer

### DIFF
--- a/pkg/client/common/discovery/dynamicdiscovery/service.go
+++ b/pkg/client/common/discovery/dynamicdiscovery/service.go
@@ -145,7 +145,11 @@ func asPeer(ctx contextAPI.Client, endpoint *discclient.Peer) (fab.Peer, bool) {
 		return nil, false
 	}
 
-	peer, err := ctx.InfraProvider().CreatePeerFromConfig(&fab.NetworkPeer{PeerConfig: *peerConfig, MSPID: endpoint.MSPID})
+	peer, err := ctx.InfraProvider().CreatePeerFromConfig(&fab.NetworkPeer{
+		PeerConfig: *peerConfig,
+		MSPID:      endpoint.MSPID,
+		Properties: fabdiscovery.GetProperties(endpoint),
+	})
 	if err != nil {
 		logger.Warnf("Unable to create peer config for [%s]: %s", url, err)
 		return nil, false

--- a/pkg/client/common/selection/fabricselection/selectionfilter_test.go
+++ b/pkg/client/common/selection/fabricselection/selectionfilter_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabricselection
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerEndpointValue(t *testing.T) {
+	const mspID = "org1"
+	const url = "peer1.org1.com"
+
+	t.Run("Success", func(t *testing.T) {
+		ep := &peerEndpointValue{
+			mspID: mspID,
+			url:   url,
+			properties: fab.Properties{
+				fab.PropertyLedgerHeight: uint64(1001),
+			},
+		}
+
+		require.Equal(t, mspID, ep.MSPID())
+		require.Equal(t, url, ep.URL())
+		require.NotEmpty(t, ep.Properties())
+		require.Equal(t, uint64(1001), ep.Properties()[fab.PropertyLedgerHeight])
+		require.Equal(t, uint64(1001), ep.BlockHeight())
+		require.Panics(t, func() {
+			_, err := ep.ProcessTransactionProposal(nil, fab.ProcessProposalRequest{})
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("No ledger height property", func(t *testing.T) {
+		ep := &peerEndpointValue{
+			mspID:      mspID,
+			url:        url,
+			properties: fab.Properties{},
+		}
+
+		require.Equal(t, mspID, ep.MSPID())
+		require.Equal(t, url, ep.URL())
+		require.Empty(t, ep.Properties())
+		require.Equal(t, uint64(0), ep.BlockHeight())
+	})
+}

--- a/pkg/common/providers/fab/network.go
+++ b/pkg/common/providers/fab/network.go
@@ -111,7 +111,8 @@ type ChannelPeer struct {
 // NetworkPeer combines peer info with MSP info
 type NetworkPeer struct {
 	PeerConfig
-	MSPID string
+	MSPID      string
+	Properties map[Property]interface{}
 }
 
 // OrganizationConfig provides the definition of an organization in the network

--- a/pkg/common/providers/fab/peer.go
+++ b/pkg/common/providers/fab/peer.go
@@ -16,10 +16,29 @@ type Peer interface {
 	//URL gets the peer address
 	URL() string
 
-	// TODO: Roles, Name, EnrollmentCertificate (if needed)
+	// Properties returns properties of the peer.
+	Properties() Properties
+
+	// TODO: Name, EnrollmentCertificate (if needed)
 }
 
 // PeerState provides state information about the Peer
 type PeerState interface {
 	BlockHeight() uint64
 }
+
+// Properties defines the properties of a peer
+type Properties map[Property]interface{}
+
+// Property is the key into the Properties map
+type Property = string
+
+// Following is a well-known list of properties of a peer, although this list may be extended.
+const (
+	// PropertyChaincodes defines the chaincodes that are deployed on the peer. Value type:[]*github.com/hyperledger/fabric-protos-go/gossip.Chaincode
+	PropertyChaincodes Property = "Chaincodes"
+	// PropertyLedgerHeight defines the ledger height property. Value type: uint64
+	PropertyLedgerHeight Property = "LedgerHeight"
+	// PropertyLeftChannel defines the "left-channel" property which indicates whether the peer left the channel. Value type: bool
+	PropertyLeftChannel Property = "LeftChannel"
+)

--- a/pkg/fab/discovery/mockdiscoveryclient.go
+++ b/pkg/fab/discovery/mockdiscoveryclient.go
@@ -196,6 +196,8 @@ func newStateInfoMessage(endpoint *mocks.MockDiscoveryPeerEndpoint) *gprotoext.S
 				StateInfo: &gossip.StateInfo{
 					Properties: &gossip.Properties{
 						LedgerHeight: endpoint.LedgerHeight,
+						Chaincodes:   endpoint.Chaincodes,
+						LeftChannel:  endpoint.LeftChannel,
 					},
 				},
 			},

--- a/pkg/fab/discovery/mocks/mockdiscoveryserver.go
+++ b/pkg/fab/discovery/mocks/mockdiscoveryserver.go
@@ -178,8 +178,9 @@ func asDiscoveryPeer(p *MockDiscoveryPeerEndpoint) *discovery.Peer {
 		Content: &gossip.GossipMessage_StateInfo{
 			StateInfo: &gossip.StateInfo{
 				Properties: &gossip.Properties{
-					Chaincodes:   nil,
 					LedgerHeight: p.LedgerHeight,
+					Chaincodes:   p.Chaincodes,
+					LeftChannel:  p.LeftChannel,
 				},
 				Timestamp: &gossip.PeerTime{
 					SeqNum: uint64(1000),
@@ -208,6 +209,8 @@ type MockDiscoveryPeerEndpoint struct {
 	MSPID        string
 	Endpoint     string
 	LedgerHeight uint64
+	Chaincodes   []*gossip.Chaincode
+	LeftChannel  bool
 }
 
 func asPeersByOrg(peers []*MockDiscoveryPeerEndpoint) map[string]*discovery.Peers {

--- a/pkg/fab/discovery/util.go
+++ b/pkg/fab/discovery/util.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"reflect"
+	"strings"
+
+	discclient "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/discovery/client"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+)
+
+// GetProperties extracts the properties from the discovered peer.
+func GetProperties(endpoint *discclient.Peer) fab.Properties {
+	if endpoint.StateInfoMessage == nil {
+		return nil
+	}
+
+	stateInfo := endpoint.StateInfoMessage.GetStateInfo()
+	if stateInfo == nil || stateInfo.Properties == nil {
+		return nil
+	}
+
+	properties := make(fab.Properties)
+
+	val := reflect.ValueOf(stateInfo.Properties).Elem()
+
+	for i := 0; i < val.NumField(); i++ {
+		fType := val.Type().Field(i)
+
+		// Exclude protobuf fields
+		if !strings.HasPrefix(fType.Name, "XXX_") {
+			properties[fType.Name] = val.Field(i).Interface()
+		}
+	}
+
+	return properties
+}

--- a/pkg/fab/discovery/util_test.go
+++ b/pkg/fab/discovery/util_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/gossip"
+	discclient "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/discovery/client"
+	gprotoext "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/gossip/protoext"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProperties(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		chaincodes := []*gossip.Chaincode{
+			{
+				Name:    "cc1",
+				Version: "v1",
+			},
+		}
+
+		endpoint := &discclient.Peer{
+			StateInfoMessage: newStateInfoMessage(&mocks.MockDiscoveryPeerEndpoint{
+				LedgerHeight: 1001,
+				Chaincodes:   chaincodes,
+				LeftChannel:  true,
+			}),
+		}
+
+		properties := GetProperties(endpoint)
+		require.NotEmpty(t, properties)
+		require.Equal(t, uint64(1001), properties[fab.PropertyLedgerHeight])
+		require.Equal(t, chaincodes, properties[fab.PropertyChaincodes])
+		require.Equal(t, true, properties[fab.PropertyLeftChannel])
+	})
+
+	t.Run("Nil state info message", func(t *testing.T) {
+		properties := GetProperties(&discclient.Peer{})
+		require.Empty(t, properties)
+	})
+
+	t.Run("Nil properties in state info message", func(t *testing.T) {
+		endpoint := &discclient.Peer{
+			StateInfoMessage: &gprotoext.SignedGossipMessage{
+				GossipMessage: &gossip.GossipMessage{
+					Content: &gossip.GossipMessage_StateInfo{
+						StateInfo: &gossip.StateInfo{},
+					},
+				},
+			},
+		}
+
+		properties := GetProperties(endpoint)
+		require.Empty(t, properties)
+	})
+}

--- a/pkg/fab/mocks/mockfabricprovider.go
+++ b/pkg/fab/mocks/mockfabricprovider.go
@@ -43,6 +43,7 @@ func (f *MockInfraProvider) CreatePeerFromConfig(peerCfg *fab.NetworkPeer) (fab.
 	if peerCfg != nil {
 		p := NewMockPeer(peerCfg.MSPID, peerCfg.URL)
 		p.SetMSPID(peerCfg.MSPID)
+		p.SetProperties(peerCfg.Properties)
 
 		return p, nil
 	}

--- a/pkg/fab/mocks/mockpeer.go
+++ b/pkg/fab/mocks/mockpeer.go
@@ -35,6 +35,7 @@ type MockPeer struct {
 	Endorser             []byte
 	ChaincodeID          string
 	RwSets               []*rwsetutil.NsRwSet
+	properties           fab.Properties
 }
 
 // NewMockPeer creates basic mock peer
@@ -63,14 +64,14 @@ func (p *MockPeer) SetMSPID(mspID string) {
 	p.MockMSP = mspID
 }
 
-// Roles returns the mock peer's mock roles
-func (p *MockPeer) Roles() []string {
-	return p.MockRoles
+// Properties returns the peer's properties
+func (p *MockPeer) Properties() fab.Properties {
+	return p.properties
 }
 
-// SetRoles sets the mock peer's mock roles
-func (p *MockPeer) SetRoles(roles []string) {
-	p.MockRoles = roles
+// SetProperties sets the peer's properties
+func (p *MockPeer) SetProperties(properties fab.Properties) {
+	p.properties = properties
 }
 
 // EnrollmentCertificate returns the mock peer's mock enrollment certificate

--- a/pkg/fab/peer/peer.go
+++ b/pkg/fab/peer/peer.go
@@ -35,6 +35,7 @@ type Peer struct {
 	failFast    bool
 	inSecure    bool
 	commManager fab.CommManager
+	properties  map[fab.Property]interface{}
 }
 
 // Option describes a functional parameter for the New constructor
@@ -146,6 +147,8 @@ func FromPeerConfig(peerCfg *fab.NetworkPeer) Option {
 		p.mspID = peerCfg.MSPID
 		p.kap = getKeepAliveOptions(peerCfg)
 		p.failFast = getFailFast(peerCfg)
+		p.properties = peerCfg.Properties
+
 		return nil
 	}
 }
@@ -214,6 +217,11 @@ func (p *Peer) URL() string {
 // ProcessTransactionProposal sends the created proposal to peer for endorsement.
 func (p *Peer) ProcessTransactionProposal(ctx reqContext.Context, proposal fab.ProcessProposalRequest) (*fab.TransactionProposalResponse, error) {
 	return p.processor.ProcessTransactionProposal(ctx, proposal)
+}
+
+// Properties returns the properties of a peer.
+func (p *Peer) Properties() fab.Properties {
+	return p.properties
 }
 
 func (p *Peer) String() string {

--- a/test/integration/pkg/fabsdk/provider/sdk_dyndiscovery_test.go
+++ b/test/integration/pkg/fabsdk/provider/sdk_dyndiscovery_test.go
@@ -49,6 +49,10 @@ func TestDynamicDiscovery(t *testing.T) {
 	for _, p := range peers {
 		t.Logf("- [%s] - MSP [%s]", p.URL(), p.MSPID())
 	}
+
+	p0 := peers[0]
+	require.NotEmpty(t, p0.Properties())
+	require.Less(t, uint64(0), p0.Properties()[fab.PropertyLedgerHeight])
 }
 
 func TestDynamicLocalDiscovery(t *testing.T) {


### PR DESCRIPTION
Properties from the discovery service are added to the fab.Peer. The properties are exposed as a map of string key to interface{} value so that extended properties may be added without requiring modifications to this interface.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>