### PR TITLE
[FABG-1024] Put valid PublicKey in client PrivateKey

### DIFF
--- a/pkg/core/config/cryptoutil/cryptoutils.go
+++ b/pkg/core/config/cryptoutil/cryptoutils.go
@@ -102,7 +102,7 @@ func X509KeyPair(certPEMBlock []byte, pk core.Key, cs core.CryptoSuite) (tls.Cer
 
 	switch x509Cert.PublicKey.(type) {
 	case *ecdsa.PublicKey:
-		cert.PrivateKey = &PrivateKey{cs, pk, &ecdsa.PublicKey{}}
+		cert.PrivateKey = &PrivateKey{cs, pk, x509Cert.PublicKey}
 	default:
 		return fail(errors.New("tls: unknown public key algorithm"))
 	}

--- a/pkg/core/config/cryptoutil/cryptoutils_test.go
+++ b/pkg/core/config/cryptoutil/cryptoutils_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package cryptoutil
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	fabricCaUtil "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric-ca/sdkinternal/pkg/util"
@@ -66,11 +67,25 @@ func TestX509KeyPair(t *testing.T) {
 	}
 
 	// ECSDA Cert
-	_, err = X509KeyPair([]byte(ecdsaCert), nil, cs)
+	cert, err := X509KeyPair([]byte(ecdsaCert), nil, cs)
 	if err != nil {
 		t.Fatalf("Failed to load key pair: %s", err)
 	}
 
+	key, ok := cert.PrivateKey.(*PrivateKey)
+	if !ok {
+		t.Fatal("Should have loaded private key as cryptoutils.PrivateKey")
+	}
+
+	pubKey, ok := key.Public().(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("Should have loaded public key as ECDSA")
+	}
+
+	// Valid public key in private key
+	if pubKey.Curve == nil {
+		t.Fatal("Should have loaded private key with valid public key")
+	}
 }
 
 func TestPrivateKey(t *testing.T) {


### PR DESCRIPTION
In some cases, the TLS 1.3 handshake was trying to get the client's public key from within the private key, but segfaulting since the public key had nil parameters.

https://jira.hyperledger.org/browse/FABG-1024

Signed-off-by: David Mazary <david@corsha.com>