### PR TITLE
Allowing discovery client users to use response.Endorsers

### DIFF
--- a/pkg/fab/discovery/discovery.go
+++ b/pkg/fab/discovery/discovery.go
@@ -62,11 +62,11 @@ type Response interface {
 	Error() error
 }
 
-// WithIndifferentFilter returns NoPriorities/NoExclusion filter.
+// NewIndifferentFilter returns NoPriorities/NoExclusion filter.
 // Note: this method was added just to allow users of Client to be able to use Endorsers method in response, which requires Filter as an argument.
 // It's impossible to implement interface because Filter is placed under internal dir which is not available to end user.
 // A user should filter peers by himself.
-func WithIndifferentFilter() discclient.Filter {
+func NewIndifferentFilter() discclient.Filter {
 	return discclient.NewFilter(discclient.NoPriorities, discclient.NoExclusion)
 }
 

--- a/pkg/fab/discovery/discovery.go
+++ b/pkg/fab/discovery/discovery.go
@@ -62,6 +62,14 @@ type Response interface {
 	Error() error
 }
 
+// WithIndifferentFilter returns NoPriorities/NoExclusion filter.
+// Note: this method was added just to allow users of Client to be able to use Endorsers method in response, which requires Filter as an argument.
+// It's impossible to implement interface because Filter is placed under internal dir which is not available to end user.
+// A user should filter peers by himself.
+func WithIndifferentFilter() discclient.Filter {
+	return discclient.NewFilter(discclient.NoPriorities, discclient.NoExclusion)
+}
+
 // Send retrieves information about channel peers, endorsers, and MSP config from the
 // given set of peers. A channel of successful responses is returned and an error if there is not targets.
 // Each Response contains Error method to check if there is an error.

--- a/pkg/fab/discovery/discovery_test.go
+++ b/pkg/fab/discovery/discovery_test.go
@@ -9,6 +9,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	discclient "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/discovery/client"
 	"net"
 	"os"
 	"testing"
@@ -140,4 +141,11 @@ func newMockContext() *mocks.MockContext {
 	context := mocks.NewMockContext(mspmocks.NewMockSigningIdentity("user1", "test"))
 	context.SetCustomInfraProvider(comm.NewMockInfraProvider())
 	return context
+}
+
+func TestWithIndifferentFilter(t *testing.T) {
+	endorsers := discclient.Endorsers{&discclient.Peer{MSPID: "org1MSP"}, &discclient.Peer{MSPID: "org2MSP"}}
+	filter := WithIndifferentFilter()
+	filteredEndorsers := filter.Filter(endorsers)
+	assert.Len(t, filteredEndorsers, len(endorsers))
 }

--- a/pkg/fab/discovery/discovery_test.go
+++ b/pkg/fab/discovery/discovery_test.go
@@ -9,13 +9,13 @@ package discovery
 import (
 	"context"
 	"fmt"
-	discclient "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/discovery/client"
 	"net"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/hyperledger/fabric-protos-go/discovery"
+	discclient "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/discovery/client"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/comm"
 	discmocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery/mocks"

--- a/pkg/fab/discovery/discovery_test.go
+++ b/pkg/fab/discovery/discovery_test.go
@@ -143,9 +143,9 @@ func newMockContext() *mocks.MockContext {
 	return context
 }
 
-func TestWithIndifferentFilter(t *testing.T) {
+func TestNewIndifferentFilter(t *testing.T) {
 	endorsers := discclient.Endorsers{&discclient.Peer{MSPID: "org1MSP"}, &discclient.Peer{MSPID: "org2MSP"}}
-	filter := WithIndifferentFilter()
+	filter := NewIndifferentFilter()
 	filteredEndorsers := filter.Filter(endorsers)
 	assert.Len(t, filteredEndorsers, len(endorsers))
 }


### PR DESCRIPTION
This method was added just to allow users of Client to be able to use Endorsers method in response, which requires Filter as an argument.
It's impossible to implement the interface because Filter is placed under internal dir which is not available to end-user.
A user should filter peers by himself.