### PR TITLE
add GetPeersOfOrg to gateway network functions

### DIFF
--- a/pkg/gateway/network.go
+++ b/pkg/gateway/network.go
@@ -64,6 +64,19 @@ func (n *Network) Name() string {
 	return n.name
 }
 
+func (n *Network) GetPeersOfOrg(mspID string) ([]fab.Peer, error) {
+	ctx := n.gateway.sdk.Context()
+	client, err := ctx()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get Client Provider")
+	}
+	ds, err := client.LocalDiscoveryProvider().CreateLocalDiscoveryService(mspID)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create Local Discovery Service")
+	}
+	return ds.GetPeers()
+}
+
 // GetContract returns instance of a smart contract on the current network.
 //  Parameters:
 //  chaincodeID is the name of the chaincode that contains the smart contract


### PR DESCRIPTION
The goal of this PR is to be able to dynamically obtain the available peers of a certain org while using the Gateway programming model. This way peers can be used to set endorsement policies without the need to know them upfront or set them statically.