### PR TITLE
Fixed errors in unit tests of 2 packages

### DIFF
--- a/pkg/client/common/discovery/greylist/greylist_test.go
+++ b/pkg/client/common/discovery/greylist/greylist_test.go
@@ -58,7 +58,7 @@ func connectionFailedStatus(url string) error {
 func createMockPeers(fromIndex int, toIndex int) []fab.Peer {
 	var mockPeers []fab.Peer
 	for i := fromIndex; i < toIndex; i++ {
-		mockPeers = append(mockPeers, mocks.NewMockPeer("testPeer"+string(i),
+		mockPeers = append(mockPeers, mocks.NewMockPeer("testPeer"+fmt.Sprint(i),
 			"grpcs://myPeer.org:"+strconv.Itoa(i)))
 	}
 	return mockPeers

--- a/pkg/fab/ccpackager/lifecycle/packager_test.go
+++ b/pkg/fab/ccpackager/lifecycle/packager_test.go
@@ -64,7 +64,7 @@ func TestNewCCPackageError(t *testing.T) {
 
 		pkgBytes, err := NewCCPackage(desc)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "'go list' failed with: can't load package: package invalid is not in GOROOT")
+		require.Contains(t, err.Error(), "'go list' failed with: package invalid is not in GOROOT")
 		require.Empty(t, pkgBytes)
 	})
 


### PR DESCRIPTION
Fixed errors in unit tests of 2 packages: pkg/client/common/discovery/greylist and pkg/fab/ccpackager/lifecycle.