### PR TITLE
add Checkpointer proposal

### DIFF
--- a/pkg/gateway/checkpoint.go
+++ b/pkg/gateway/checkpoint.go
@@ -1,0 +1,35 @@
+package gateway
+
+
+// A Checkpoint stores checkpointer information to persist current block and transactions.
+// Instances are created using factory methods on the implementing objects.
+type Checkpoint struct {
+	store CheckpointStore
+}
+
+//  Get current Block number stored in a checkpoint
+func (cp *Checkpoint) GetBlockNumber() uint64 {
+	return cp.store.GetBlockNumber()
+}
+
+// Set Block number to store in a checkpoint
+//  Parameters:
+//  blockNumber specifies the number of the block to be stored.
+func (cp *Checkpoint) SetBlockNumber(blockNumber uint64)  {
+	cp.store.SetBlockNumber(blockNumber)
+}
+
+
+//  Get current Transactions ids stored in a checkpoint
+func (cp *Checkpoint) GetTransactionIds() []string {
+	return cp.store.GetTransactionIds()
+}
+
+
+// Add transaction Id to store in an array of transactions of a checkpoint
+//  Parameters:
+//  transactionId specifies id of the transaction to be stored.
+func (cp *Checkpoint) AddTransactionId(transactionId string) {
+	cp.store.AddTransactionId(transactionId)
+}
+

--- a/pkg/gateway/filecheckpoint.go
+++ b/pkg/gateway/filecheckpoint.go
@@ -1,0 +1,99 @@
+package gateway
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	VERSION int = 1
+	UNSET_BLOCK_NUMBER uint64 = -1
+)
+
+// checkpoint is the persistence state
+type checkpoint struct {
+	version int
+	blockNumber uint64
+	transactionIds []string
+}
+
+// fileCheckpoint stores checkpointer information to persist current block and transactions
+// Instances are created using NewFileCheckpoint()
+type fileCheckpoint struct {
+	path string
+	blockNumber uint64
+	transactionsIds []string
+}
+
+
+// NewFileCheckpoint creates an instance of a checkpoint,
+//  Parameters:
+//  path specifies where on the filesystem to store the checkpoint.
+//  Returns:
+//  A Checkpoint object.
+func NewFileCheckpoint(path string) (*Checkpoint, error) {
+	cleanPath := filepath.Clean(path)
+	transactions := make([]string,0)
+	blockNumber := UNSET_BLOCK_NUMBER
+
+	store := &fileCheckpoint{cleanPath, blockNumber, transactions }
+
+	if _, err := os.Stat(cleanPath); os.IsExist(err) {
+		// triggers if dir already exists
+		store.load()
+	} else {
+		store.save()
+	}
+
+	return &Checkpoint{store}, nil
+}
+
+// load loads the information of block and transactions from a json format file
+func (fcp *fileCheckpoint) load(){
+	data := checkpoint{}
+	file, _ := ioutil.ReadFile(fcp.path)
+	json.Unmarshal(file, &data)
+	fcp.setState(data)
+}
+
+// setState puts the information of block and transactions to the fileCheckpoint struct
+func (fcp *fileCheckpoint) setState(data checkpoint) {
+	fcp.blockNumber = data.blockNumber
+	fcp.transactionsIds = data.transactionIds;
+}
+
+// save puts the information of block and transactions in a json file
+func (fcp *fileCheckpoint) save() {
+	data := checkpoint{
+		version: VERSION,
+		blockNumber: fcp.blockNumber,
+		transactionIds: fcp.transactionsIds,
+	}
+	jsonData, _ := json.MarshalIndent(data, "", " ");
+	_ = ioutil.WriteFile(fcp.path, jsonData, 0644)
+}
+
+// GetBlockNumber from a checkpoint
+func (fcp *fileCheckpoint) GetBlockNumber() uint64 {
+	return fcp.blockNumber
+}
+
+// SetBlockNumber of a checkpoint
+func (fcp *fileCheckpoint) SetBlockNumber(blockNumber uint64)  {
+	fcp.blockNumber = blockNumber
+	fcp.transactionsIds = nil
+	fcp.save()
+}
+
+// GetTransactionIds from a checkpoint
+func (fcp *fileCheckpoint) GetTransactionIds() []string {
+	return fcp.transactionsIds
+}
+
+// AddTransactionId to array of block transactions held in a checkpoint
+func (fcp *fileCheckpoint) AddTransactionId(transactionId string) {
+	fcp.transactionsIds = append(fcp.transactionsIds, transactionId)
+	fcp.save()
+}

--- a/pkg/gateway/spi.go
+++ b/pkg/gateway/spi.go
@@ -24,3 +24,19 @@ type WalletStore interface {
 	Exists(label string) bool
 	Remove(label string) error
 }
+
+// CheckpointStore is the interface for implementations that need to persist current block and transactions to
+// enable event listening to be resumed following an application failure.
+// To create create a new checkpòinter, implement all the methods defined in this interface and provide
+// a factory method that wraps an instance of this in a new Checkpoint object. E.g:
+//   func NewCheckpoint() *Checkpoint {
+//	   store := &myCheckpoint{ }
+//	   return &Checkpoint{store}
+//   }
+type CheckpointStore interface {
+	GetBlockNumber() uint64
+	SetBlockNumber(blockNumber uint64)
+	GetTransactionIds() []string
+	AddTransactionId(transactionId string)
+}
+


### PR DESCRIPTION
The goal of this PR is to propose a way to do event checkpointing using Go SDK, this is a a desirable feature to replay missed events emitted by peers.

Node SDK and Java SDK have this feature, in Java, when a client starts to listen to events, they inject the checkpointer like this:  

contract.addContractListener(
  newCheckpointer("checkpointer.json"),
  handler
  "Event"
)

We want to emulate this using Go, we have a question before we continue with unit testing and the injection of the checkpointer itself:

- What is the best way to approach the injection of the checkpointer ? We were thinking adding it as a parameter 
 in the RegisterEvent function https://pkg.go.dev/github.com/chrainwang/fabric-sdk-go/pkg/gateway#Contract.RegisterEvent
so the client doesn't need to worry about nothing.


Signed-off-by: jsebastianms1 <jsebastianms1@gmail.com>