### PR TITLE
add HSM Identity proposal

### DIFF
--- a/pkg/gateway/hsmx509identity.go
+++ b/pkg/gateway/hsmx509identity.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"encoding/json"
+)
+
+const Hsmx509type = "HSM-X.509"
+
+// Hsmx509Identity represents an Hsmx509 identity
+type Hsmx509Identity struct {
+	IDType      string      `json:"type"`
+	Version     int         `json:"version"`
+	MspID       string      `json:"mspId"`
+	Credentials credentials `json:"credentials"`
+}
+
+// Type returns Hsmx509 for this identity type
+func (x *Hsmx509Identity) idType() string {
+	return Hsmx509type
+}
+
+func (x *Hsmx509Identity) mspID() string {
+	return x.MspID
+}
+
+// Certificate returns the Hsmx509 certificate PEM
+func (x *Hsmx509Identity) Certificate() string {
+	return x.Credentials.Certificate
+}
+
+// Key returns the private key PEM
+func (x *Hsmx509Identity) Key() string {
+	return x.Credentials.Key
+}
+
+// NewHsmx509Identity creates an Hsmx509 identity for storage in a wallet
+func NewHsmx509Identity(mspid string, cert string, key string) *Hsmx509Identity {
+	return &Hsmx509Identity{Hsmx509type, 1, mspid, credentials{cert, key}}
+}
+
+func (x *Hsmx509Identity) toJSON() ([]byte, error) {
+	return json.Marshal(x)
+}
+
+func (x *Hsmx509Identity) fromJSON(data []byte) (Identity, error) {
+	err := json.Unmarshal(data, x)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return x, nil
+}

--- a/pkg/gateway/hsmx509identityprovider.go
+++ b/pkg/gateway/hsmx509identityprovider.go
@@ -1,0 +1,49 @@
+package gateway
+
+import (
+	"encoding/json"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
+)
+
+const ProviderType = "HSM-X.509"
+
+
+type HsmOptions struct {
+	Lib         string      `json:"lib"`
+	Pin         string      `json:"pin"`
+	Slot        string      `json:"slot"`
+	UserType    string      `json:"usertype"`
+	ReadWrite   bool      `json:"readwrite"`
+}
+
+type Hsmx509IdentityProvider struct {
+	Type           string             `json:"type"`
+	Options        HsmOptions         `json:"options"`
+	CryptoSuite    core.CryptoSuite   `json:"cryptosuite"`
+}
+
+/*
+func (p Hsmx509IdentityProvider) GetCryptoSuite() core.CryptoSuite {
+
+}
+*/
+
+func (p Hsmx509IdentityProvider) FromJson(data []byte) (Identity, error) {
+	err := json.Unmarshal(data, p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (p Hsmx509IdentityProvider) ToJson() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+/*
+func (p Hsmx509IdentityProvider) GetUserContext(identity Hsmx509Identity, name string) (Identity, error) {
+	return
+}
+*/

--- a/pkg/gateway/identityprovider.go
+++ b/pkg/gateway/identityprovider.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
+)
+
+// IdentityProvider is the interface that represents an identity provider
+type IdentityProvider interface {
+	GetCryptoSuite() core.CryptoSuite
+	FromJSON(data []byte) (Identity, error)
+	ToJSON() ([]byte, error)
+	GetUserContext(identity Hsmx509Identity, name string)
+}

--- a/pkg/gateway/identityproviderregistry.go
+++ b/pkg/gateway/identityproviderregistry.go
@@ -1,0 +1,24 @@
+package gateway
+
+
+const defaultProviders []IdentityProvider
+
+type IdentityProviderRegistry struct {
+	providers map[string]IdentityProvider
+}
+
+func (ipr IdentityProviderRegistry) GetProvider(registrytype string) (IdentityProvider, error){
+	provider := ipr.providers[registrytype]
+	if (provider == nil) {
+		return nil, error.Wrap("No Identity Provider Registry was found")
+	}
+	return provider, nil
+}
+
+
+
+func (ipr IdentityProviderRegistry) DefaultProviderRegistry() (IdentityProviderRegistry) {
+	registry := IdentityProviderRegistry{}
+	for _, provider := range defaultProviders {
+	}
+}


### PR DESCRIPTION
Hello, we are trying to use HSM with the GO SDK, our objective is to use it with a wallet, some kind of identityprovider, we are creating this PR to interact with you, so you can guide us further:

- Is this the right approach for this project?
- Using Cryptosuite with PKCS11 interface is not as clear as we wanted it to be.
- Using identitymanager or using the mspwallet to create a manager is not explained thoroughly

We want to do something like this(inspired by the node SDK): https://github.com/hyperledger/fabric-sdk-node/blob/main/fabric-network/src/impl/wallet/hsmx509identity.ts 

We have some of the possible interfaces and some of the functions, but when we think how to link everything with a wallet, we just don't know if the path we are following is correct

Hope you can guide us, thanks a lot!