### PR TITLE
Fixed a bug in proposal matcher when querying committed chaincodes. P…

### DIFF
--- a/pkg/client/resmgmt/lifecycleclient_test.go
+++ b/pkg/client/resmgmt/lifecycleclient_test.go
@@ -841,6 +841,17 @@ func TestClient_LifecycleQueryCommittedCC(t *testing.T) {
 	lcDefsBytes, err := proto.Marshal(lcDefs)
 	require.NoError(t, err)
 
+	//this result is used to test a case when peers return list of definitions in unexpected order
+	lcDefsInDifferentOrder := &lb.QueryChaincodeDefinitionsResult{
+		ChaincodeDefinitions: []*lb.QueryChaincodeDefinitionsResult_ChaincodeDefinition{
+			{Name: cc2, Sequence: 2, Version: v1, ValidationParameter: policyBytes},
+			{Name: cc1, Sequence: 1, Version: v1, ValidationParameter: policyBytes, Collections: collections},
+		},
+	}
+
+	lcDefsInDifferentOrderBytes, err := proto.Marshal(lcDefsInDifferentOrder)
+	require.NoError(t, err)
+
 	ctx := setupTestContext("test", "Org1MSP")
 	ctx.SetEndpointConfig(getNetworkConfig(t))
 
@@ -862,6 +873,13 @@ func TestClient_LifecycleQueryCommittedCC(t *testing.T) {
 			ProposalResponse: &pb.ProposalResponse{
 				Response: &pb.Response{
 					Payload: lcDefsBytes,
+				},
+			},
+		},
+		{
+			ProposalResponse: &pb.ProposalResponse{
+				Response: &pb.Response{
+					Payload: lcDefsInDifferentOrderBytes,
 				},
 			},
 		},

--- a/pkg/client/resmgmt/lifecycleprocessor.go
+++ b/pkg/client/resmgmt/lifecycleprocessor.go
@@ -582,8 +582,8 @@ func unmarshalInOrderCCDefResults(name string, payload []byte) (proto.Message, e
 		return result, errors.Wrap(err, "failed to unmarshal payload into QueryChaincodeDefinitionsResult")
 	}
 
-	// need to sort them by name because peers return list of chaincodes in unexpected order(slice).
-	// proto.Equal fails to compare them
+	// need to sort cc definitions by name because peers return lists of chaincodes in an unexpected order.
+	// proto.Equal fails to compare them because slice is used, thus it compares each value x[i] == x[j]
 	sort.Slice(result.ChaincodeDefinitions, func(i, j int) bool {
 		return result.ChaincodeDefinitions[i].Name > result.ChaincodeDefinitions[j].Name
 	})

--- a/pkg/client/resmgmt/lifecycleprocessor.go
+++ b/pkg/client/resmgmt/lifecycleprocessor.go
@@ -9,6 +9,7 @@ package resmgmt
 import (
 	reqContext "context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -571,5 +572,16 @@ func unmarshalCCDefResults(name string, payload []byte) (proto.Message, error) {
 	}
 
 	result := &lb.QueryChaincodeDefinitionsResult{}
-	return result, proto.Unmarshal(payload, result)
+
+	if err := proto.Unmarshal(payload, result); err != nil {
+		return result, err
+	}
+
+	// need to sort them by name because peers return list of chaincodes in unexpected order(slice).
+	// proto.Equal fails to compare them
+	sort.Slice(result.ChaincodeDefinitions, func(i, j int) bool {
+		return result.ChaincodeDefinitions[i].Name > result.ChaincodeDefinitions[j].Name
+	})
+
+	return result, nil
 }

--- a/pkg/client/resmgmt/lifecycleprocessor.go
+++ b/pkg/client/resmgmt/lifecycleprocessor.go
@@ -282,7 +282,7 @@ func (p *lifecycleProcessor) queryCommitted(reqCtx reqContext.Context, channelID
 
 	err = p.verifyResponsesMatch(txProposalResponse,
 		func(payload []byte) (proto.Message, error) {
-			return unmarshalCCDefResults(req.Name, payload)
+			return unmarshalInOrderCCDefResults(req.Name, payload)
 		},
 	)
 	if err != nil {
@@ -565,16 +565,21 @@ func (p *lifecycleProcessor) verifyResponsesMatch(responses []*fab.TransactionPr
 	return nil
 }
 
-func unmarshalCCDefResults(name string, payload []byte) (proto.Message, error) {
+// unmarshalls payload into QueryChaincodeDefinition(s)Result and sorts chaincodes by name
+func unmarshalInOrderCCDefResults(name string, payload []byte) (proto.Message, error) {
 	if name != "" {
 		result := &lb.QueryChaincodeDefinitionResult{}
-		return result, proto.Unmarshal(payload, result)
+		if err := proto.Unmarshal(payload, result); err != nil {
+			return result, errors.Wrapf(err, "failed to unmarshal payload with name %s into QueryChaincodeDefinitionResult", name)
+		}
+
+		return result, nil
 	}
 
 	result := &lb.QueryChaincodeDefinitionsResult{}
 
 	if err := proto.Unmarshal(payload, result); err != nil {
-		return result, err
+		return result, errors.Wrap(err, "failed to unmarshal payload into QueryChaincodeDefinitionsResult")
 	}
 
 	// need to sort them by name because peers return list of chaincodes in unexpected order(slice).

--- a/pkg/client/resmgmt/lifecycleprocessor_test.go
+++ b/pkg/client/resmgmt/lifecycleprocessor_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright IntellectEU, NV. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/pkg/client/resmgmt/lifecycleprocessor_test.go
+++ b/pkg/client/resmgmt/lifecycleprocessor_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package resmgmt
 
 import (

--- a/pkg/client/resmgmt/lifecycleprocessor_test.go
+++ b/pkg/client/resmgmt/lifecycleprocessor_test.go
@@ -1,0 +1,55 @@
+package resmgmt
+
+import (
+	"github.com/golang/protobuf/proto"
+	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestUnmarshalInOrderCCDefResults(t *testing.T) {
+	t.Run("unmarshalls and sorts chaincodes by name", func(t *testing.T) {
+		aCCDefRes := &lb.QueryChaincodeDefinitionsResult{
+			ChaincodeDefinitions: []*lb.QueryChaincodeDefinitionsResult_ChaincodeDefinition{
+				{Name: "a", Sequence: 1, Version: "v1"},
+				{Name: "b", Sequence: 2, Version: "v5"},
+				{Name: "c", Sequence: 2, Version: "v5"},
+			},
+		}
+
+		bCCDefRes := &lb.QueryChaincodeDefinitionsResult{
+			ChaincodeDefinitions: []*lb.QueryChaincodeDefinitionsResult_ChaincodeDefinition{},
+		}
+
+		//set cc definitions in reversed order
+		for i := len(aCCDefRes.ChaincodeDefinitions) - 1; i >= 0; i-- {
+			bCCDefRes.ChaincodeDefinitions = append(bCCDefRes.ChaincodeDefinitions, aCCDefRes.ChaincodeDefinitions[i])
+		}
+
+		aCCefResBytes, err := proto.Marshal(aCCDefRes)
+		require.NoError(t, err)
+
+		bCCDefResBytes, err := proto.Marshal(bCCDefRes)
+		require.NoError(t, err)
+
+		a, err := unmarshalInOrderCCDefResults("", aCCefResBytes)
+		require.NoError(t, err)
+		b, err := unmarshalInOrderCCDefResults("", bCCDefResBytes)
+		require.NoError(t, err)
+
+		assert.True(t, proto.Equal(a, b))
+	})
+
+	t.Run("fails to unmarshall a payload into QueryChaincodeDefinitionsResult", func(t *testing.T) {
+		_, err := unmarshalInOrderCCDefResults("", []byte("some unknown payload"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal payload into QueryChaincodeDefinitionsResult")
+	})
+
+	t.Run("fails to unmarshall a payload into QueryChaincodeDefinitionResult", func(t *testing.T) {
+		_, err := unmarshalInOrderCCDefResults("someName", []byte("some unknown payload"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal payload with name someName into QueryChaincodeDefinitionResult")
+	})
+}

--- a/pkg/client/resmgmt/lifecycleprocessor_test.go
+++ b/pkg/client/resmgmt/lifecycleprocessor_test.go
@@ -1,11 +1,12 @@
 package resmgmt
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestUnmarshalInOrderCCDefResults(t *testing.T) {


### PR DESCRIPTION
This PR fixes an error in the proposal matcher with an unexpected order of committed chaincodes returned from a peer. The matcher uses `proto.Equal` which fails to compare the values of slices that are in a different order.   
Two peers return the same list of the chaincodes in a slice instead of a map, that's why the order can't be guaranteed https://github.com/hyperledger/fabric/blob/main/core/chaincode/lifecycle/scc.go#L620.

Signed-off-by: Vladyslav Kopaihorodskyi <vlad.kopaygorodsky@gmail.com>