### PR TITLE
Better error message for missing mspid connection

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -129,7 +129,7 @@ func WithConfig(config core.ConfigProvider) ConfigOption {
 
 		value, ok = gw.cfg.Lookup("organizations." + gw.org + ".mspid")
 		if !ok {
-			return errors.New("No client organization defined in the config")
+			return errors.New("No mspid defined in the config for " + gw.org)
 		}
 		gw.mspid = value.(string)
 


### PR DESCRIPTION
When mspid is missing in connection yaml , the sdk gives a slightly misleading error message - "No client organization defined in the config" (which implies client.org is not been defined in connection.yaml) . We can give a better  error message to imply that mspid is missing - No mspid defined in the config for Org1

-------------------example wrong config-----------
name: voterNet-investorOrg
version: 1.0.0
client:
  organization: investorOrg
  connection:
    timeout:
      peer:
        endorser: '300'
organizations:
  investorOrg:    (mspid missing)
    peers:
    - peer0.investorOrg.voternet.com
    certificateAuthorities:
    - ca.investorOrg.voternet.com