### PR TITLE
feat(gateway): add WithBlockNum option

### DIFF
--- a/pkg/gateway/contract_test.go
+++ b/pkg/gateway/contract_test.go
@@ -13,7 +13,9 @@ import (
 func TestCreateTransaction(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	nw, err := newNetwork(gw, c)
 
@@ -38,7 +40,9 @@ func TestCreateTransaction(t *testing.T) {
 func TestCreateTransactionNamespaced(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	nw, err := newNetwork(gw, c)
 
@@ -65,7 +69,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	gw := &Gateway{
 		options: &gatewayOptions{
-			Timeout:   defaultTimeout,
+			Timeout: defaultTimeout,
 		},
 	}
 
@@ -93,7 +97,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	gw := &Gateway{
 		options: &gatewayOptions{
-			Timeout:   defaultTimeout,
+			Timeout: defaultTimeout,
 		},
 	}
 
@@ -121,7 +125,7 @@ func TestContractEvent(t *testing.T) {
 
 	gw := &Gateway{
 		options: &gatewayOptions{
-			Timeout:   defaultTimeout,
+			Timeout: defaultTimeout,
 		},
 	}
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -52,6 +52,9 @@ type gatewayOptions struct {
 	Identity mspProvider.SigningIdentity
 	User     string
 	Timeout  time.Duration
+	// FromBlock specify the initial block to be considerer by event client
+	FromBlock    uint64
+	FromBlockSet bool
 }
 
 // Option functional arguments can be supplied when connecting to the gateway.
@@ -236,6 +239,15 @@ func WithUser(user string) IdentityOption {
 func WithTimeout(timeout time.Duration) Option {
 	return func(gw *Gateway) error {
 		gw.options.Timeout = timeout
+		return nil
+	}
+}
+
+// WithBlockNum optionaly indicates the block number from which events are to be received.
+func WithBlockNum(from uint64) Option {
+	return func(gw *Gateway) error {
+		gw.options.FromBlock = from
+		gw.options.FromBlockSet = true
 		return nil
 	}
 }

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -72,6 +72,24 @@ func TestConnectNoOptions(t *testing.T) {
 	}
 }
 
+func TestConnectWithBlockNum(t *testing.T) {
+	gw, err := Connect(
+		WithConfig(config.FromFile("testdata/connection-tls.json")),
+		WithUser("user1"),
+		WithBlockNum(2),
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to create gateway: %s", err)
+	}
+
+	options := gw.options
+
+	if !options.FromBlockSet || options.FromBlock != 2 {
+		t.Fatal("BlockNum not correctly initialized")
+	}
+}
+
 func TestConnectWithSDK(t *testing.T) {
 	sdk, err := fabsdk.New(config.FromFile("testdata/connection-tls.json"))
 

--- a/pkg/gateway/network.go
+++ b/pkg/gateway/network.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/event"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/deliverclient/seek"
 	"github.com/pkg/errors"
 )
 
@@ -43,7 +44,12 @@ func newNetwork(gateway *Gateway, channelProvider context.ChannelProvider) (*Net
 
 	n.name = ctx.ChannelID()
 
-	n.event, err = event.New(channelProvider, event.WithBlockEvents())
+	eventOpts := []event.ClientOption{event.WithBlockEvents()}
+	if gateway.options.FromBlockSet {
+		eventOpts = append(eventOpts, event.WithSeekType(seek.FromBlock), event.WithBlockNum(gateway.options.FromBlock))
+	}
+
+	n.event, err = event.New(channelProvider, eventOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create new event client")
 	}

--- a/pkg/gateway/network_test.go
+++ b/pkg/gateway/network_test.go
@@ -18,7 +18,9 @@ import (
 func TestNewNetwork(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	nw, err := newNetwork(gw, c)
 
@@ -34,7 +36,9 @@ func TestNewNetwork(t *testing.T) {
 func TestGetContract(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	nw, err := newNetwork(gw, c)
 
@@ -53,7 +57,9 @@ func TestGetContract(t *testing.T) {
 func TestGetContractWithName(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	nw, err := newNetwork(gw, c)
 
@@ -120,7 +126,9 @@ func TestFilteredBlocktEvent(t *testing.T) {
 func TestNewNetworkFailure1(t *testing.T) {
 	c := mockBadChannelProvider("mychannel", 2)
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	_, err := newNetwork(gw, c)
 
@@ -132,7 +140,9 @@ func TestNewNetworkFailure1(t *testing.T) {
 func TestNewNetworkFailure2(t *testing.T) {
 	c := mockBadChannelProvider("mychannel", 3)
 
-	gw := &Gateway{}
+	gw := &Gateway{
+		options: &gatewayOptions{},
+	}
 
 	_, err := newNetwork(gw, c)
 

--- a/pkg/gateway/network_test.go
+++ b/pkg/gateway/network_test.go
@@ -33,6 +33,23 @@ func TestNewNetwork(t *testing.T) {
 	}
 }
 
+func TestNewNetworkWithEventOptions(t *testing.T) {
+	c := mockChannelProvider("mychannel")
+
+	gw := &Gateway{
+		options: &gatewayOptions{
+			FromBlock:    2,
+			FromBlockSet: true,
+		},
+	}
+
+	_, err := newNetwork(gw, c)
+
+	if err != nil {
+		t.Fatalf("Failed to create network: %s", err)
+	}
+}
+
 func TestGetContract(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 


### PR DESCRIPTION
## Rationale

I have a use case where each organization has an application that listens to chaincode events through the gateway and react accordingly.
All events should be processed, even when starting the application after the other organizations.

## Proposed changes

Currently the gateway only supports listening to *new* events, not existing ones, although the event client has such capability.
This PR introduces a new gateway option to let the user specify from which block to start listening to events.

## Design choices

`FromBlockSet` is a flag since `0` would be a valid block number, we need to determine if the user has explicitly set a starting block number.