### PR TITLE
custom wallets for gateway model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-module github.com/hyperledger/fabric-sdk-go
+module github.com/anonsachin/fabric-sdk-go
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible

--- a/pkg/client/channel/chclient_test.go
+++ b/pkg/client/channel/chclient_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
 	txnmocks "github.com/hyperledger/fabric-sdk-go/pkg/client/common/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/common/selection/staticselection"
@@ -27,8 +29,6 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/txn"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	"github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 const (

--- a/pkg/client/common/discovery/dynamicdiscovery/localprovider_test.go
+++ b/pkg/client/common/discovery/dynamicdiscovery/localprovider_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery"
 	contextAPI "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
 	pfab "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery"
 	discmocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"

--- a/pkg/client/common/discovery/dynamicdiscovery/localservice_test.go
+++ b/pkg/client/common/discovery/dynamicdiscovery/localservice_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	contextAPI "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	pfab "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
@@ -20,6 +19,7 @@ import (
 	discmocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/discovery/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/client/common/selection/dynamicselection/dynamicselection_test.go
+++ b/pkg/client/common/selection/dynamicselection/dynamicselection_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/common/selection/dynamicselection/pgresolver"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/common/selection/options"
@@ -19,7 +20,6 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	"github.com/hyperledger/fabric-protos-go/common"
 )
 
 const (

--- a/pkg/client/common/selection/dynamicselection/pgresolver/pgresolver_test.go
+++ b/pkg/client/common/selection/dynamicselection/pgresolver/pgresolver_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	common "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	mocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
-	common "github.com/hyperledger/fabric-protos-go/common"
 )
 
 const (

--- a/pkg/client/event/event_test.go
+++ b/pkg/client/event/event_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/deliverclient/seek"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/dispatcher"
 	servicemocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/mocks"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 var (

--- a/pkg/common/errors/retry/retry_test.go
+++ b/pkg/common/errors/retry/retry_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/common/errors/status/status_test.go
+++ b/pkg/common/errors/status/status_test.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/multi"
 	"github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/multi"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	grpccodes "google.golang.org/grpc/codes"

--- a/pkg/fab/channel/ledger_test.go
+++ b/pkg/fab/channel/ledger_test.go
@@ -14,13 +14,13 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/multi"
 	contextApi "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/fab/channel/membership/cache_test.go
+++ b/pkg/fab/channel/membership/cache_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	mb "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/util/concurrent/lazyref"
-	mb "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/fab/channel/transactor_test.go
+++ b/pkg/fab/channel/transactor_test.go
@@ -306,13 +306,13 @@ func TestExcludedOrdrerer(t *testing.T) {
 	var orderersCfgs []fab.OrdererConfig
 	for _, v := range networkConfig.Orderers {
 		orderersCfgs = append(orderersCfgs, fab.OrdererConfig{
-			URL: v.URL,
+			URL:         v.URL,
 			GRPCOptions: v.GRPCOptions,
 		})
 	}
 
 	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
-		Orderers: []string{}})  // empty channel.Orderers SDK config, to force fetching from orderers SDK config
+		Orderers: []string{}}) // empty channel.Orderers SDK config, to force fetching from orderers SDK config
 	mockEndpoingCfg.EXPECT().OrdererConfig("example.com").Return(&orderersCfgs[0], true, false)
 	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(&orderersCfgs[1], true, false)
 	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true) // true means ignored
@@ -342,7 +342,6 @@ func TestExcludedOrdrerer(t *testing.T) {
 	assert.NotEmpty(t, o)
 	assert.Equal(t, 2, len(o), "expected 2 orderers from response orderers list")
 
-
 	// now retry the same previous two tests with channelConfig returning list of orderers
 	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
 		Orderers: chConfig.MockOrderers}) // read orderers from channel.Orderers SDK config
@@ -361,10 +360,10 @@ func TestExcludedOrdrerer(t *testing.T) {
 
 	// now try with example2.com not found, to be populated from chConfig
 	mockEndpoingCfg.EXPECT().ChannelConfig("mychannel").Return(&fab.ChannelEndpointConfig{
-		Orderers: chConfig.MockOrderers})  // read orderers from channel.Orderers SDK config
+		Orderers: chConfig.MockOrderers}) // read orderers from channel.Orderers SDK config
 	mockEndpoingCfg.EXPECT().OrdererConfig("example.com").Return(&orderersCfgs[0], true, false) // found
-	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(nil, false, false) // not found
-	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true) // excluded
+	mockEndpoingCfg.EXPECT().OrdererConfig("example2.com").Return(nil, false, false)            // not found
+	mockEndpoingCfg.EXPECT().OrdererConfig("example3.com").Return(nil, false, true)             // excluded
 
 	ctx.SetEndpointConfig(mockEndpoingCfg)
 
@@ -372,8 +371,8 @@ func TestExcludedOrdrerer(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, o)
 	assert.Equal(t, 1, len(o),
-		"expected 1 orderer from response orderers list since 1 orderer is not found " +
-		"and another is excluded")
+		"expected 1 orderer from response orderers list since 1 orderer is not found "+
+			"and another is excluded")
 }
 
 //endpointConfigEntity contains endpoint config elements needed by endpointconfig

--- a/pkg/fab/comm/comm_test.go
+++ b/pkg/fab/comm/comm_test.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"testing"
 
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	eventmocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/fab/events/deliverclient/connection/connection_test.go
+++ b/pkg/fab/events/deliverclient/connection/connection_test.go
@@ -15,14 +15,14 @@ import (
 
 	"google.golang.org/grpc/keepalive"
 
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/comm"
 	clientdisp "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/client/dispatcher"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/deliverclient/seek"
 	eventmocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/mocks"
 	fabmocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	cb "github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )

--- a/pkg/fab/events/service/blockfilter/headertypefilter/headertypefilter_test.go
+++ b/pkg/fab/events/service/blockfilter/headertypefilter/headertypefilter_test.go
@@ -9,9 +9,9 @@ package headertypefilter
 import (
 	"testing"
 
-	servicemocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/mocks"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	servicemocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/mocks"
 )
 
 func TestHeaderTypeBlockFilter(t *testing.T) {

--- a/pkg/fab/events/service/dispatcher/dispatcher_test.go
+++ b/pkg/fab/events/service/dispatcher/dispatcher_test.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/blockfilter"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/blockfilter/headertypefilter"
 	servicemocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/mocks"
-	cb "github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 var sourceURL = "localhost:9051"

--- a/pkg/fab/events/service/service_test.go
+++ b/pkg/fab/events/service/service_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/dispatcher"
 	servicemocks "github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/mocks"
 
-	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/blockfilter/headertypefilter"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/events/service/blockfilter/headertypefilter"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/fab/matchers_test.go
+++ b/pkg/fab/matchers_test.go
@@ -605,7 +605,7 @@ func testIgnoreEndpointOrdererSearch(t *testing.T, config fab.EndpointConfig) {
 
 	//Test if orderer excluded in orderer search by name
 
-	ordererConfig, ok, ignoreOrderer:= config.OrdererConfig("orderer.exclude.example.com")
+	ordererConfig, ok, ignoreOrderer := config.OrdererConfig("orderer.exclude.example.com")
 	assert.False(t, ok)
 	assert.True(t, ignoreOrderer, "orderer must be excluded")
 	assert.Nil(t, ordererConfig)

--- a/pkg/fab/orderer/orderer_test.go
+++ b/pkg/fab/orderer/orderer_test.go
@@ -525,14 +525,14 @@ func TestForGRPCErrorsWithKeepAliveOpts(t *testing.T) {
 }
 
 func TestNewOrdererFromOrdererName(t *testing.T) {
-	t.Run("run simple FromOrdererName", func(t *testing.T){
+	t.Run("run simple FromOrdererName", func(t *testing.T) {
 		_, err := New(mocks.NewMockEndpointConfig(), FromOrdererName("orderer"))
 		if err != nil {
 			t.Fatalf("Failed to get new orderer from name. Error: %s", err)
 		}
 	})
 
-	t.Run("run FromOrdererName with Ignore orderer in config", func(t *testing.T){
+	t.Run("run FromOrdererName with Ignore orderer in config", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 		mockEndpoingCfg := mockfab.NewMockEndpointConfig(mockCtrl)
@@ -545,7 +545,7 @@ func TestNewOrdererFromOrdererName(t *testing.T) {
 		}
 	})
 
-	t.Run("run FromOrdererName with orderer not found in config", func(t *testing.T){
+	t.Run("run FromOrdererName with orderer not found in config", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 		mockEndpoingCfg := mockfab.NewMockEndpointConfig(mockCtrl)

--- a/pkg/fab/resource/configtxmsp_test.go
+++ b/pkg/fab/resource/configtxmsp_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/test/metadata"
 
-	mspcfg "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric-protos-go/msp"
+	mspcfg "github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/msp"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/fab/txn/proposal_test.go
+++ b/pkg/fab/txn/proposal_test.go
@@ -19,13 +19,13 @@ import (
 
 	"time"
 
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/multi"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	mock_context "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/test/mockfab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 const (

--- a/pkg/fab/txn/txn_test.go
+++ b/pkg/fab/txn/txn_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 	"github.com/hyperledger/fabric-sdk-go/pkg/context"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/mocks"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	"github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 func TestNewTransaction(t *testing.T) {

--- a/pkg/gateway/filesystemwallet.go
+++ b/pkg/gateway/filesystemwallet.go
@@ -37,7 +37,7 @@ func NewFileSystemWallet(path string) (*Wallet, error) {
 	}
 
 	store := &fileSystemWalletStore{cleanPath}
-	return &Wallet{store}, nil
+	return WalletFromStore(store), nil
 
 }
 

--- a/pkg/gateway/inmemorywallet.go
+++ b/pkg/gateway/inmemorywallet.go
@@ -20,7 +20,7 @@ type inMemoryWalletStore struct {
 //  A Wallet object.
 func NewInMemoryWallet() *Wallet {
 	store := &inMemoryWalletStore{make(map[string][]byte, 10)}
-	return &Wallet{store}
+	return WalletFromStore(store)
 }
 
 // Put an identity into the wallet.

--- a/pkg/gateway/spi.go
+++ b/pkg/gateway/spi.go
@@ -24,3 +24,11 @@ type WalletStore interface {
 	Exists(label string) bool
 	Remove(label string) error
 }
+
+// To allow for custom wallets.
+
+// WalletFromStore is a simple way that allows to create custom wallets
+// based on the user's requirements.
+func WalletFromStore(store WalletStore) *Wallet{
+	return &Wallet{store}
+}

--- a/pkg/gateway/spi.go
+++ b/pkg/gateway/spi.go
@@ -29,6 +29,6 @@ type WalletStore interface {
 
 // WalletFromStore is a simple way that allows to create custom wallets
 // based on the user's requirements.
-func WalletFromStore(store WalletStore) *Wallet{
+func WalletFromStore(store WalletStore) *Wallet {
 	return &Wallet{store}
 }

--- a/pkg/msp/filekeystore_test.go
+++ b/pkg/msp/filekeystore_test.go
@@ -17,10 +17,9 @@ import (
 func TestCryptoConfigPrivKeyPathV1(t *testing.T) {
 	const (
 		cryptoConfigPath = "testdata/cryptoconfig/v1/{username}"
-		username = "user"
+		username         = "user"
 	)
-	ski := []byte{0,1}
-
+	ski := []byte{0, 1}
 
 	p := cryptoConfigPrivateKeyPath(cryptoConfigPath, username, ski)
 	assert.Contains(t, p, "0001_sk")
@@ -29,9 +28,9 @@ func TestCryptoConfigPrivKeyPathV1(t *testing.T) {
 func TestCryptoConfigPrivKeyPathV2(t *testing.T) {
 	const (
 		cryptoConfigRelPath = "testdata/cryptoconfig/v2/{username}"
-		username = "user"
+		username            = "user"
 	)
-	ski := []byte{0,1}
+	ski := []byte{0, 1}
 
 	cryptoConfigPath := filepath.Join(testDir(), cryptoConfigRelPath)
 	t.Log(cryptoConfigPath)


### PR DESCRIPTION
Creating custom wallets is not possible as of now as the store is private property, This will provide an easy way of creating Custom Wallets as each wallet can have its own method of initializing the store and passing it into the wallet, as seen in the filesystem and In-memory wallets. I have used the function in both the default wallets.

```
// WalletFromStore is a simple way that allows to create custom wallets
// based on the user's requirements.
func WalletFromStore(store WalletStore) *Wallet{
	return &Wallet{store}
}
```

Use in filesystem Wallet

```
func NewFileSystemWallet(path string) (*Wallet, error) {
	cleanPath := filepath.Clean(path)
	err := os.MkdirAll(cleanPath, os.ModePerm)

	if err != nil {
		return nil, err
	}

	store := &fileSystemWalletStore{cleanPath}
	return WalletFromStore(store), nil

}
```

similarly also in In-memory wallet.

Following a function similar to [NewCryptoSuite.](https://github.com/hyperledger/fabric-sdk-go/blob/7bf58790be693b74f78e37393781988244b0290b/pkg/core/cryptosuite/bccsp/wrapper/cryptosuiteimpl.go#L17

Wanted to have a simple way like the [Node SDK wallet .](https://github.com/hyperledger/fabric-sdk-node/blob/2b8b63c9d42f3ba96956faae00812afc7c7bb3ad/docs/tutorials/wallet.md)