### PR TITLE
Fix bug

### DIFF
--- a/pkg/fab/ccpackager/gopackager/packager.go
+++ b/pkg/fab/ccpackager/gopackager/packager.go
@@ -13,6 +13,7 @@ import (
 	"go/build"
 	"io"
 	"os"
+	"runtime"
 	"path/filepath"
 	"time"
 
@@ -89,6 +90,7 @@ func NewCCPackage(chaincodePath string, goPath string) (*resource.CCPackage, err
 // -------------------------------------------------------------------------
 func findSource(goPath string, filePath string) ([]*Descriptor, error) {
 	var descriptors []*Descriptor
+	os_type := runtime.GOOS
 	err := filepath.Walk(filePath,
 		func(path string, fileInfo os.FileInfo, err error) error {
 			if err != nil {
@@ -101,6 +103,9 @@ func findSource(goPath string, filePath string) ([]*Descriptor, error) {
 				}
 				if strings.Contains(relPath, "/META-INF/") {
 					relPath = relPath[strings.Index(relPath, "/META-INF/")+1:]
+				}
+				if os_type == "windows"{
+					relPath = strings.Replace(relPath, "\\", "/", -1)
 				}
 				descriptors = append(descriptors, &Descriptor{name: relPath, fqp: path})
 			}

--- a/pkg/fab/ccpackager/gopackager/packager.go
+++ b/pkg/fab/ccpackager/gopackager/packager.go
@@ -90,7 +90,7 @@ func NewCCPackage(chaincodePath string, goPath string) (*resource.CCPackage, err
 // -------------------------------------------------------------------------
 func findSource(goPath string, filePath string) ([]*Descriptor, error) {
 	var descriptors []*Descriptor
-	os_type := runtime.GOOS
+	osType := runtime.GOOS
 	err := filepath.Walk(filePath,
 		func(path string, fileInfo os.FileInfo, err error) error {
 			if err != nil {
@@ -104,7 +104,7 @@ func findSource(goPath string, filePath string) ([]*Descriptor, error) {
 				if strings.Contains(relPath, "/META-INF/") {
 					relPath = relPath[strings.Index(relPath, "/META-INF/")+1:]
 				}
-				if os_type == "windows"{
+				if osType == "windows"{
 					relPath = strings.Replace(relPath, "\\", "/", -1)
 				}
 				descriptors = append(descriptors, &Descriptor{name: relPath, fqp: path})


### PR DESCRIPTION
when I use fabric-sdk-go(my computer os is windows 10 ) to deploy chaincode,occur an error "Failed to generate platform-specific docker build: Error returned from build: 1 "can't load package: package github.com/testchaincode1: cannot find package "github.com/testchaincode1" in any of: ",but it can normal run in ubuntu,the sdk config almost same except tls and private key path, and they connect same fabric network.

I fix it by modify fabric-sdk-go,so I think It shoud be a bug