### PR TITLE
Get proposal response payload from chaincode action

### DIFF
--- a/pkg/client/channel/chclient_test.go
+++ b/pkg/client/channel/chclient_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
 	txnmocks "github.com/hyperledger/fabric-sdk-go/pkg/client/common/mocks"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/common/selection/staticselection"
@@ -27,8 +29,6 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/txn"
 	mspmocks "github.com/hyperledger/fabric-sdk-go/pkg/msp/test/mockmsp"
-	"github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 const (

--- a/pkg/client/channel/invoke/txnhandler.go
+++ b/pkg/client/channel/invoke/txnhandler.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"strings"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/options"
 	"github.com/pkg/errors"
@@ -63,7 +64,13 @@ func (e *EndorsementHandler) Handle(requestContext *RequestContext, clientContex
 
 	requestContext.Response.Responses = transactionProposalResponses
 	if len(transactionProposalResponses) > 0 {
-		requestContext.Response.Payload = transactionProposalResponses[0].ProposalResponse.GetResponse().Payload
+		responsePayload, err := getResultFromProposalResponse(transactionProposalResponses[0].ProposalResponse)
+		if err != nil {
+			requestContext.Error = err
+			return
+		}
+
+		requestContext.Response.Payload = responsePayload
 		requestContext.Response.ChaincodeStatus = transactionProposalResponses[0].ChaincodeStatus
 	}
 
@@ -71,6 +78,24 @@ func (e *EndorsementHandler) Handle(requestContext *RequestContext, clientContex
 	if e.next != nil {
 		e.next.Handle(requestContext, clientContext)
 	}
+}
+
+func getResultFromProposalResponse(proposalResponse *pb.ProposalResponse) ([]byte, error) {
+	responsePayload := &pb.ProposalResponsePayload{}
+	if err := proto.Unmarshal(proposalResponse.GetPayload(), responsePayload); err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize proposal response payload")
+	}
+
+	return getResultFromProposalResponsePayload(responsePayload)
+}
+
+func getResultFromProposalResponsePayload(responsePayload *pb.ProposalResponsePayload) ([]byte, error) {
+	chaincodeAction := &pb.ChaincodeAction{}
+	if err := proto.Unmarshal(responsePayload.GetExtension(), chaincodeAction); err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize chaincode action")
+	}
+
+	return chaincodeAction.GetResponse().GetPayload(), nil
 }
 
 //ProposalProcessorHandler for selecting proposal processors

--- a/test/scripts/chaincoded.sh
+++ b/test/scripts/chaincoded.sh
@@ -17,11 +17,11 @@ unset GOCACHE
 
 echo "Installing chaincodes ..."
 cd ${CHAINCODE_PATH}/github.com/example_cc
-go install github.com/example_cc
+${GO_CMD} install github.com/example_cc
 cd ${CHAINCODE_PATH}/github.com/example_pvt_cc
-go install github.com/example_pvt_cc
+${GO_CMD} install github.com/example_pvt_cc
 cd ${CHAINCODED_PATH}
-go install chaincoded/cmd/chaincoded
+${GO_CMD} install chaincoded/cmd/chaincoded
 
 PEERS=(
     peer0.org1.example.com:7052

--- a/test/scripts/check_lint.sh
+++ b/test/scripts/check_lint.sh
@@ -12,8 +12,8 @@ GO_CMD="${GO_CMD:-go}"
 SCRIPT_DIR="$(dirname "$0")"
 PKG_ROOT="${PKG_ROOT:-./}"
 
-PROJECT_MODULE=$(awk -F' ' '$1 == "module" {print $2}' < $(go env GOMOD))
-PROJECT_DIR=$(dirname $(go env GOMOD))
+PROJECT_MODULE=$(awk -F' ' '$1 == "module" {print $2}' < $(${GO_CMD} env GOMOD))
+PROJECT_DIR=$(dirname $(${GO_CMD} env GOMOD))
 
 CONFIG_DIR=${PROJECT_DIR}
 

--- a/test/scripts/check_version.sh
+++ b/test/scripts/check_version.sh
@@ -8,8 +8,10 @@
 PROJECT_NAME="hyperledger/fabric-sdk-go"
 MAX_RELEASE_VER_FATAL=0
 
+GO_CMD="${GO_CMD:-go}"
+
 echo "Checking Go version"
-GO_VER_FULL=`go version`
+GO_VER_FULL=`${GO_CMD} version`
 echo ${GO_VER_FULL}
 GO_VER=`echo ${GO_VER_FULL} |awk '{print $3}'`
 

--- a/test/scripts/dependencies.sh
+++ b/test/scripts/dependencies.sh
@@ -58,14 +58,14 @@ function installGoPkg {
 
     echo "Installing ${repo}@${revision} to $GOPATH/bin ..."
 
-    GO111MODULE=off GOPATH=${BUILD_TMP} go get -d ${repo}
+    GO111MODULE=off GOPATH=${BUILD_TMP} ${GO_CMD} get -d ${repo}
     tag=$(cd ${BUILD_TMP}/src/${repo} && git tag -l --sort=-version:refname | head -n 1 | grep "${revision}" || true)
     if [ ! -z "${tag}" ]; then
         revision=${tag}
         echo "  using tag ${revision}"
     fi
     (cd ${BUILD_TMP}/src/${repo} && git reset --hard ${revision})
-    GO111MODULE=off GOPATH=${BUILD_TMP} GOBIN=${BUILD_TMP}/bin go install -i ${repo}/${pkgPath}
+    GO111MODULE=off GOPATH=${BUILD_TMP} GOBIN=${BUILD_TMP}/bin ${GO_CMD} install -i ${repo}/${pkgPath}
 
     mkdir -p ${GOPATH}/bin
     for cmd in ${cmds[@]}
@@ -119,7 +119,7 @@ function isDependenciesInstalled {
     declare -a msgs=()
 
     # Check that Go tools are installed and help the user if they are missing
-    type ${GOBIN_CMD} >/dev/null 2>&1 || msgs+=("${GOBIN_CMD} is not installed (GO111MODULE=off go get -u github.com/myitcv/gobin)")
+    type ${GOBIN_CMD} >/dev/null 2>&1 || msgs+=("${GOBIN_CMD} is not installed (GO111MODULE=off ${GO_CMD} get -u github.com/myitcv/gobin)")
 
     if [ ${#msgs[@]} -gt 0 ]; then
         if [ ${printMsgs} = true ]; then


### PR DESCRIPTION
This is the correct chaincode transaction response payload location. The response payload field is intended to contain metadata but the peer currently copies the transaction response payload here for convenience. This causes failures due to gRPC message size limits for large response payloads and so may be removed in the future.

Also changed a few build scripts to honour the GO_CMD environment variable.