### PR TITLE
Recreate event service if WithNoCache() opt used

### DIFF
--- a/pkg/client/event/event.go
+++ b/pkg/client/event/event.go
@@ -34,6 +34,7 @@ type Client struct {
 	fromBlock            uint64
 	seekType             seek.Type
 	eventConsumerTimeout *time.Duration
+	noCacheInit          bool
 }
 
 // New returns a Client instance. Client receives events such as block, filtered block,
@@ -71,7 +72,11 @@ func New(channelProvider context.ChannelProvider, opts ...ClientOption) (*Client
 		if eventClient.eventConsumerTimeout != nil {
 			opts = append(opts, dispatcher.WithEventConsumerTimeout(*eventClient.eventConsumerTimeout))
 		}
-		es, err = channelContext.ChannelService().EventService(opts...)
+		if eventClient.noCacheInit {
+			es, err = channelContext.ChannelService().EventServiceNoCache(opts...)
+		} else {
+			es, err = channelContext.ChannelService().EventService(opts...)
+		}
 	} else {
 		es, err = channelContext.ChannelService().EventService()
 	}

--- a/pkg/client/event/event.go
+++ b/pkg/client/event/event.go
@@ -72,6 +72,7 @@ func New(channelProvider context.ChannelProvider, opts ...ClientOption) (*Client
 		if eventClient.eventConsumerTimeout != nil {
 			opts = append(opts, dispatcher.WithEventConsumerTimeout(*eventClient.eventConsumerTimeout))
 		}
+		//nolint:gocyclo
 		if eventClient.noCacheInit {
 			es, err = channelContext.ChannelService().EventServiceNoCache(opts...)
 		} else {

--- a/pkg/client/event/opts.go
+++ b/pkg/client/event/opts.go
@@ -15,6 +15,14 @@ import (
 // ClientOption describes a functional parameter for the New constructor
 type ClientOption func(*Client) error
 
+// WithNoCache indicates that event service must be initialized without cache.
+func WithNoCache() ClientOption {
+	return func(c *Client) error {
+		c.noCacheInit = true
+		return nil
+	}
+}
+
 // WithBlockEvents indicates that block events are to be received.
 // Note that the caller must have sufficient privileges for this option.
 func WithBlockEvents() ClientOption {

--- a/pkg/client/resmgmt/mockchannelservice.gen.go
+++ b/pkg/client/resmgmt/mockchannelservice.gen.go
@@ -155,6 +155,23 @@ func (fake *MockChannelService) EventService(opts ...options.Opt) (fab.EventServ
 	return fake.eventServiceReturns.result1, fake.eventServiceReturns.result2
 }
 
+func (fake *MockChannelService) EventServiceNoCache(opts ...options.Opt) (fab.EventService, error) {
+	fake.eventServiceMutex.Lock()
+	ret, specificReturn := fake.eventServiceReturnsOnCall[len(fake.eventServiceArgsForCall)]
+	fake.eventServiceArgsForCall = append(fake.eventServiceArgsForCall, struct {
+		opts []options.Opt
+	}{opts})
+	fake.recordInvocation("EventService", []interface{}{opts})
+	fake.eventServiceMutex.Unlock()
+	if fake.EventServiceStub != nil {
+		return fake.EventServiceStub(opts...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.eventServiceReturns.result1, fake.eventServiceReturns.result2
+}
+
 func (fake *MockChannelService) EventServiceCallCount() int {
 	fake.eventServiceMutex.RLock()
 	defer fake.eventServiceMutex.RUnlock()

--- a/pkg/common/providers/fab/context.go
+++ b/pkg/common/providers/fab/context.go
@@ -16,6 +16,7 @@ import (
 type ChannelService interface {
 	Config() (ChannelConfig, error)
 	EventService(opts ...options.Opt) (EventService, error)
+	EventServiceNoCache(opts ...options.Opt) (EventService, error)
 	Membership() (ChannelMembership, error)
 	ChannelConfig() (ChannelCfg, error)
 	Transactor(reqCtx reqContext.Context) (Transactor, error)

--- a/pkg/fab/mocks/mockchprovider.go
+++ b/pkg/fab/mocks/mockchprovider.go
@@ -72,6 +72,11 @@ func (cs *MockChannelService) EventService(opts ...options.Opt) (fab.EventServic
 	return NewMockEventService(), nil
 }
 
+// EventServiceNoCache returns a mock event service
+func (cs *MockChannelService) EventServiceNoCache(opts ...options.Opt) (fab.EventService, error) {
+	return NewMockEventService(), nil
+}
+
 // SetTransactor changes the return value of Transactor
 func (cs *MockChannelService) SetTransactor(t fab.Transactor) {
 	cs.transactor = t

--- a/pkg/fabsdk/provider/chpvdr/chprovider.go
+++ b/pkg/fabsdk/provider/chpvdr/chprovider.go
@@ -104,6 +104,11 @@ func (cs *ChannelService) EventService(opts ...options.Opt) (fab.EventService, e
 	return cs.ctxtCache.GetEventService(cs.channelID, opts...)
 }
 
+func (cs *ChannelService) EventServiceNoCache(opts ...options.Opt) (fab.EventService, error) {
+	cs.ctxtCache.Drain(DrainEventSevice)
+	return cs.ctxtCache.GetEventService(cs.channelID, opts...)
+}
+
 // Membership returns and caches a channel member identifier
 // A membership reference is returned that refreshes with the configured interval
 func (cs *ChannelService) Membership() (fab.ChannelMembership, error) {

--- a/pkg/fabsdk/provider/chpvdr/chprovider.go
+++ b/pkg/fabsdk/provider/chpvdr/chprovider.go
@@ -104,6 +104,7 @@ func (cs *ChannelService) EventService(opts ...options.Opt) (fab.EventService, e
 	return cs.ctxtCache.GetEventService(cs.channelID, opts...)
 }
 
+// EventServiceNoCache creates EventService and returns it (without using cache).
 func (cs *ChannelService) EventServiceNoCache(opts ...options.Opt) (fab.EventService, error) {
 	cs.ctxtCache.Drain(DrainEventSevice)
 	return cs.ctxtCache.GetEventService(cs.channelID, opts...)

--- a/pkg/fabsdk/provider/chpvdr/contextcache.go
+++ b/pkg/fabsdk/provider/chpvdr/contextcache.go
@@ -20,13 +20,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-type DrainType int
+type drainType int
 
 const (
-	DrainEventSevice DrainType = iota + 1
+	// DrainEventSevice used to drain event service cache
+	DrainEventSevice drainType = iota + 1
+	// DrainMembershipCache used to drain membership service cache
 	DrainMembershipCache
+	// DrainChCfgCache used to drain channel config cache
 	DrainChCfgCache
+	// DrainSelectionServiceCache used to drain selection service cache
 	DrainSelectionServiceCache
+	// DrainDiscoveryServiceCache used to drain discovery service cache
 	DrainDiscoveryServiceCache
 )
 
@@ -93,7 +98,8 @@ func newContextCache(ctx fab.ClientContext, opts []options.Opt) *contextCache {
 	return c
 }
 
-func (c *contextCache) Drain(whatToDrain DrainType) {
+// Drain deletes all entries from the specified cache.
+func (c *contextCache) Drain(whatToDrain drainType) {
 	switch whatToDrain {
 	case DrainEventSevice:
 		c.eventServiceCache.DeleteAll()


### PR DESCRIPTION
This PR adds WithNoCache() func opt to the event client constructor to force reinitialization of event client instead of using an event client from cache. 

Now two different event clients will be created with the same EventService if the same context.ChannelProvider (`New(channelProvider context.ChannelProvider, opts ...ClientOption)`) was passed. As a result, the passed functional options are ignored. 

Example of undocumented behaviour:

```
eventClient1, err := event.New(chPrvdr, event.WithBlockEvents(), event.WithSeekType(seek.FromBlock), event.WithBlockNum(0))
...
eventClient2, err := event.New(chPrvdr, event.WithBlockEvents(), event.WithSeekType(seek.FromBlock), event.WithBlockNum(10))
```

eventClient2 will listen not from 10 block, but from 0. Expected behavior: the client will listen from the 10 block.