### PR TITLE
wallets with custom walletstores as backends

### DIFF
--- a/pkg/gateway/filesystemwallet.go
+++ b/pkg/gateway/filesystemwallet.go
@@ -37,7 +37,7 @@ func NewFileSystemWallet(path string) (*Wallet, error) {
 	}
 
 	store := &fileSystemWalletStore{cleanPath}
-	return &Wallet{store}, nil
+	return NewWalletWithStore(store), nil
 
 }
 

--- a/pkg/gateway/wallet.go
+++ b/pkg/gateway/wallet.go
@@ -25,6 +25,16 @@ type wallet interface {
 	List() ([]string, error)
 }
 
+// NewWalletWithStore is used for creating wallets with custom walletstores as backends.
+//  Parameters:
+//  store is the WalletStore you want to use as the backend for the wallet.
+//
+//  Returns:
+//  The Wallet object.
+func NewWalletWithStore(store WalletStore) *Wallet {
+	return &Wallet{store: store}
+}
+
 // A Wallet stores identity information used to connect to a Hyperledger Fabric network.
 // Instances are created using factory methods on the implementing objects.
 type Wallet struct {


### PR DESCRIPTION
As the Wallet struct's store field is unexported it cannot be set outside the gateway package. This pull request adds a simple function to make it possible to have a custom WalletStore's.