### PR TITLE
Add WithInit() to support chaincodes that require init

### DIFF
--- a/pkg/gateway/transaction.go
+++ b/pkg/gateway/transaction.go
@@ -119,11 +119,21 @@ func (txn *Transaction) Evaluate(args ...string) ([]byte, error) {
 // will be evaluated on the endorsing peers and then submitted to the ordering service
 // for committing to the ledger.
 func (txn *Transaction) Submit(args ...string) ([]byte, error) {
+	return txn.submit(false, args...)
+}
+
+// SubmitInit sends an initialization transaction, for chaincodes that requires init before processing regular transactions
+func (txn *Transaction) SubmitInit(args ...string) ([]byte, error) {
+	return txn.submit(true, args...)
+}
+
+func (txn *Transaction) submit(isInit bool, args ...string) ([]byte, error) {
 	bytes := make([][]byte, len(args))
 	for i, v := range args {
 		bytes[i] = []byte(v)
 	}
 	txn.request.Args = bytes
+	txn.request.IsInit = isInit
 
 	var options []channel.RequestOption
 	if txn.endorsingPeers != nil {

--- a/pkg/gateway/transaction_test.go
+++ b/pkg/gateway/transaction_test.go
@@ -80,6 +80,56 @@ func TestTransactionOptions(t *testing.T) {
 	txn.Submit("arg1", "arg2")
 }
 
+func TestInitTransactionOptions(t *testing.T) {
+	transient := make(map[string][]byte)
+	transient["price"] = []byte("8500")
+
+	c := mockChannelProvider("mychannel")
+
+	gw := &Gateway{
+		options: &gatewayOptions{
+			Timeout: defaultTimeout,
+		},
+	}
+
+	nw, err := newNetwork(gw, c)
+
+	if err != nil {
+		t.Fatalf("Failed to create network: %s", err)
+	}
+
+	contr := nw.GetContract("contract1")
+
+	txn, err := contr.CreateTransaction(
+		"txn1",
+		WithTransient(transient),
+		WithEndorsingPeers("peer1"),
+		WithCollections("_implicit_org_org1"),
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to create transaction: %s", err)
+	}
+
+	data := txn.request.TransientMap["price"]
+	if string(data) != "8500" {
+		t.Fatalf("Incorrect transient data: %s", string(data))
+	}
+
+	endorsers := txn.endorsingPeers
+	if endorsers[0] != "peer1" {
+		t.Fatalf("Incorrect endorsing peer: %s", endorsers[0])
+	}
+
+	collections := txn.collections
+	if collections[0] != "_implicit_org_org1" {
+		t.Fatalf("Incorrect collection: %s", collections[0])
+	}
+
+	txn.Evaluate("arg1", "arg2")
+	txn.SubmitInit("arg1", "arg2")
+}
+
 func TestCommitEvent(t *testing.T) {
 	c := mockChannelProvider("mychannel")
 

--- a/pkg/gateway/transaction_test.go
+++ b/pkg/gateway/transaction_test.go
@@ -105,6 +105,7 @@ func TestInitTransactionOptions(t *testing.T) {
 		WithTransient(transient),
 		WithEndorsingPeers("peer1"),
 		WithCollections("_implicit_org_org1"),
+		WithInit(),
 	)
 
 	if err != nil {
@@ -127,7 +128,7 @@ func TestInitTransactionOptions(t *testing.T) {
 	}
 
 	txn.Evaluate("arg1", "arg2")
-	txn.SubmitInit("arg1", "arg2")
+	txn.Submit("arg1", "arg2")
 }
 
 func TestCommitEvent(t *testing.T) {


### PR DESCRIPTION
Even though the latest recommendation from the Fabric team is to step away from requiring `init`, a lot of customers still use this approach, and the official docs for Fabric chaincode lifecycle still describes the `--init-required` parameter, finally the `fabric-samples` that is used widely by tire-kickers still implements `InitLedger()`.

Added a new `SubmitInit()` instead of modifying the existing signature to allow backward compatibility