### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,16 +5,16 @@
 | Name | GitHub | email |
 |---|---|---|
 | Andrew Coleman | andrew-coleman | andrew_coleman@uk.ibm.com |
-| Aleksandar Likic | alikic | aleksandar.likic@securekey.com |
 | Bob Stasyszyn | bstasyszyn | bob.stasyszyn@securekey.com |
-| Firas.Qutishat | fqutishat | firas.qutishat@securekey.com |
 | Troy Ronda | troyronda | troy@troyronda.com |
 
 ### Retired Maintainers
 
 | Name | GitHub | email |
 |---|---|---|
-| Jim Zhang | jimthematrix | jim_the_matrix@hotmail.com |
+| Aleksandar Likic | alikic | aleksandar.likic@securekey.com |
+| Firas.Qutishat | fqutishat | firas.qutishat@securekey.com |
 | Gari Singh | mastersingh24 | gari.r.singh@gmail.com |
+| Jim Zhang | jimthematrix | jim_the_matrix@hotmail.com |
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>