### PR TITLE
Supports loading of config values for Orderer.Endpoints

### DIFF
--- a/pkg/fab/chconfig/chconfig.go
+++ b/pkg/fab/chconfig/chconfig.go
@@ -590,7 +590,7 @@ func loadConfigValue(configItems *ChannelCfg, key string, versionsValue *common.
 	//	}
 	//	// TODO: Do something with this value
 
-	case channelConfig.OrdererAddressesKey:
+	case channelConfig.OrdererAddressesKey, channelConfig.EndpointsKey:
 		if err := loadOrdererAddressesKey(configValue, configItems); err != nil {
 			return err
 		}


### PR DESCRIPTION
fabric version: [release-2.2](https://github.com/hyperledger/fabric/tree/release-2.2)

configtx.yaml(release-2.2): [configtx.yaml](https://github.com/hyperledger/fabric-samples/blob/v2.2.0/test-network/configtx/configtx.yaml)

sdk_config file : [config_e2e.yaml](https://github.com/hyperledger/fabric-sdk-go/blob/main/test/fixtures/config/config_e2e.yaml) without `certificateAuthorities` config

When I call the chaincode transaction using the code below, fabric-sdk-go returns 'orderers is nil'. I found out that this is due to the channel configuration of the application channel with Orderer.Endpoints but not OrdererAddresses, and the loadConfigValue function does not support "Endpoints" configuration loading.

```golang
func main() {
	sdk, err := fabsdk.New(config.FromFile("config_e2e.yaml"))
	if err != nil {
		log.Fatalln(err)
	}
	defer sdk.Close()
	cli, err := channel.New(sdk.ChannelContext("mychannel", fabsdk.WithUser("Admin"), fabsdk.WithOrg("Org1"),
	))
	if err != nil {
		log.Fatalln(err)
	}
	resp, err := cli.Execute(channel.Request{
		ChaincodeID: "abstore",
		Fcn:         "init",
		Args:        [][]byte{[]byte("a"), []byte("100"), []byte("b"), []byte("200")},
		IsInit:      true,
	})
	if err != nil {
		log.Fatalln(err)
	}
	log.Println(string(resp.TransactionID))
}
```

Signed-off-by: smallsixFight smallsix.fight@gmail.com