### PR TITLE
Import cert sanitation fix from fabric main repo

### DIFF
--- a/internal/github.com/hyperledger/fabric/msp/cert.go
+++ b/internal/github.com/hyperledger/fabric/msp/cert.go
@@ -107,9 +107,9 @@ func sanitizeECDSASignedCert(cert *x509.Certificate, parentCert *x509.Certificat
 
 	// 2. Change the signature
 	newCert.SignatureValue = asn1.BitString{Bytes: expectedSig, BitLength: len(expectedSig) * 8}
+	newCert.Raw = nil
 
 	// 3. marshal again newCert. Raw must be nil
-	newCert.Raw = nil
 	newRaw, err := asn1.Marshal(newCert)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling of the certificate failed")

--- a/internal/github.com/hyperledger/fabric/msp/mspimpl.go
+++ b/internal/github.com/hyperledger/fabric/msp/mspimpl.go
@@ -34,7 +34,7 @@ type validateIdentityOUsFuncType func(id *identity) error
 // satisfiesPrincipalInternalFuncType is the prototype of the function to check if principals are satisfied
 type satisfiesPrincipalInternalFuncType func(id Identity, principal *m.MSPPrincipal) error
 
-//setupAdminInternalFuncType is a prototype of the function to setup the admins
+// setupAdminInternalFuncType is a prototype of the function to setup the admins
 type setupAdminInternalFuncType func(conf *m.FabricMSPConfig) error
 
 // This is an instantiation of an MSP that
@@ -778,28 +778,42 @@ func (msp *bccspmsp) getCertificationChainIdentifierFromChain(chain []*x509.Cert
 // do have signatures in Low-S. If this is not the case, the certificate
 // is regenerated to have a Low-S signature.
 func (msp *bccspmsp) sanitizeCert(cert *x509.Certificate) (*x509.Certificate, error) {
+	var err error
 	if isECDSASignedCert(cert) {
+		isRootCACert := false
+		validityOpts := msp.getValidityOptsForCert(cert)
+		if cert.IsCA && cert.CheckSignatureFrom(cert) == nil {
+			// this is a root CA we can already sanitize it
+			cert, err = sanitizeECDSASignedCert(cert, cert)
+			if err != nil {
+				return nil, err
+			}
+			isRootCACert = true
+			validityOpts.Roots = x509.NewCertPool()
+			validityOpts.Roots.AddCert(cert)
+		}
 		// Lookup for a parent certificate to perform the sanitization
-		var parentCert *x509.Certificate
-		chain, err := msp.getUniqueValidationChain(cert, msp.getValidityOptsForCert(cert))
+		// run cert validation at any rate, if this is a root CA
+		// we will validate already sanitized cert
+		chain, err := msp.getUniqueValidationChain(cert, validityOpts)
 		if err != nil {
 			return nil, err
 		}
 
-		// at this point, cert might be a root CA certificate
-		// or an intermediate CA certificate
-		if cert.IsCA && len(chain) == 1 {
-			// cert is a root CA certificate
-			parentCert = cert
-		} else {
-			parentCert = chain[1]
+		// once we finish validation and this is already
+		// sanitized certificate, there is no need to
+		// sanitize it once again hence we can just return it
+		if isRootCACert {
+			return cert, nil
 		}
+
+		// ok, this is no a root CA cert, and now we
+		// then we have chain of certs and can get parent
+		// to sanitize the cert whenever it's intermediate or leaf certificate
+		parentCert := chain[1]
 
 		// Sanitize
-		cert, err = sanitizeECDSASignedCert(cert, parentCert)
-		if err != nil {
-			return nil, err
-		}
+		return sanitizeECDSASignedCert(cert, parentCert)
 	}
 	return cert, nil
 }


### PR DESCRIPTION
There was a fix https://github.com/hyperledger/fabric/pull/3774 provided for Fabric to fix the issue after upgrading to Golang v1.19, which changed the verification of the certs chain. This fix is essential to be able to run with fabric-sdk-go; otherwise, it will fail certification validation. 